### PR TITLE
Fix build error with symlink_install and object libs

### DIFF
--- a/src/misc/safety_manager/CMakeLists.txt
+++ b/src/misc/safety_manager/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-ament_auto_add_library(safety_manager_lib OBJECT
+ament_auto_add_library(safety_manager_lib STATIC
   src/SafetyManagerNode.cpp)
 target_include_directories(safety_manager_lib PUBLIC include)
 


### PR DESCRIPTION
@wheitman noticed that using colcon build --symlink-install caused the safety manager to fail to build. Turns out, you can't just symlink-install an OBJECT library, so I've made it STATIC instead as a quick fix. 