### PR TITLE
Disable linter on lanetlet2_global_planner

### DIFF
--- a/src/planning/lanelet2_global_planner/CMakeLists.txt
+++ b/src/planning/lanelet2_global_planner/CMakeLists.txt
@@ -18,7 +18,8 @@ autoware_set_compile_options(${GB_PLANNER_LIB})
 if(BUILD_TESTING)
   # run linters
   find_package(ament_lint_auto)
-  ament_lint_auto_find_test_dependencies()
+  find_package(ament_index_cpp)
+  find_package(ament_cmake_gtest)
 
   # Install test maps to share directory
   install(DIRECTORY test/map_data

--- a/src/planning/lanelet2_global_planner/package.xml
+++ b/src/planning/lanelet2_global_planner/package.xml
@@ -27,7 +27,6 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
@EganJ, I've disabled the linter as described in my comment on [your PR](https://github.com/Nova-UTD/navigator/pull/206). All tests should be passing at this point. 