### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,9 +129,26 @@ RUN apt-get update && apt update && apt upgrade -y && \
     software-properties-common \
     # cleanup to make image smaller
     && apt clean && rm -rf /var/lib/apt/lists/*
+   
+# Install Python 3.11
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y python3.11 python3.11-dev python3.11-venv python3.11-distutils && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 2 && \
+    update-alternatives --set python3 /usr/bin/python3.11 && \
+    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
+    
+# install cmake 3.24+
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.24.4/cmake-3.24.4-linux-x86_64.tar.gz
+RUN tar -zxvf cmake-3.24.4-linux-x86_64.tar.gz
+RUN mv cmake-3.24.4-linux-x86_64 /opt/cmake
+RUN ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
 
 # pip3 installs
-RUN pip3 install \
+RUN pip3 install --ignore-installed \
     #
     autopep8==2.3.1 \
     #
@@ -227,8 +244,9 @@ RUN mim install "mmdet3d>=1.1.0"
 
 # install loop closure package "MapClosures"
 # this issue was addressed here: https://github.com/abetlen/llama-cpp-python/issues/707
+RUN python3 -m pip uninstall -y exceptiongroup
 RUN sudo apt remove python3-pathspec -y
-RUN pip3 install --user pathspec yamllint
+RUN pip3 install --no-cache-dir pathspec yamllint "exceptiongroup<=1.2.0"
 RUN git clone https://github.com/PRBonn/MapClosures.git
 WORKDIR MapClosures
 RUN cmake -B build -S cpp


### PR DESCRIPTION
There were two issues in the Dockerfile that caused the below command to fail.
```shell
docker compose build navigator
``` 

These issues were: 

1. The Docker container was being created with Cmake 3.22.1, but we needed Cmake 3.24+ due to external packages changing their requirements.
2. The MapClosures package had its dependencies updated, and those dependencies required Python 3.11, but we had Python 3.10 in the Docker container, so that also had to be updated. 