### PR TITLE
Fix CMAKE Version Requirement

### DIFF
--- a/src/msg/ros-carla-msgs/CMakeLists.txt
+++ b/src/msg/ros-carla-msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 4.1.0)
 project(carla_msgs)
 
 find_package(ros_environment REQUIRED)


### PR DESCRIPTION
# Fix CMAKE Version

Updated the existing `ros_carla_msgs` CMAKE version requirement to the project's specified version. This fixed an error when attempting to run the CARLA bridge to simulate Navigator.