### PR TITLE
feat(lane_change): shadow-mode lane change decision node (PR 1)

### DIFF
--- a/launches/launch_node_definitions.py
+++ b/launches/launch_node_definitions.py
@@ -249,3 +249,11 @@ road_user_detector = Node(
     package='road_user_detection',
     executable='road_user_detection'
 )
+
+lane_change_controller = Node(
+    package='navigator_lane_change',
+    executable='lane_change_node',
+    name='lane_change_node',
+    output='screen',
+    parameters=[NAVIGATOR_DIR + 'param/lane_change_params.yaml']
+)

--- a/param/lane_change_params.yaml
+++ b/param/lane_change_params.yaml
@@ -8,6 +8,7 @@ lane_change_node:
     path_topic: /planning/path
     objects_topic: /objdet3d_tracked
     intersection_topic: /intersection_status
+    command_topic: /behavior/lane_change_command
 
     # Need detection
     lookahead_distance_m: 35.0
@@ -27,6 +28,7 @@ lane_change_node:
     min_rear_gap_m: 10.0
     min_rear_ttc_s: 4.0
     min_side_clearance_m: 2.0
+    merging_conflict_lat_speed_mps: 0.4  # m/s lateral — flags vehicle merging into target lane
 
     # Execution constraints (not used in shadow mode — reserved for PR 3)
     max_lane_change_speed_mps: 8.0

--- a/param/lane_change_params.yaml
+++ b/param/lane_change_params.yaml
@@ -1,0 +1,41 @@
+lane_change_node:
+  ros__parameters:
+    loop_rate_hz: 10.0
+    shadow_mode: true           # Set false only after CARLA shadow validation
+
+    # Topics — match current Navigator stack names
+    odom_topic: /gnss/odometry
+    path_topic: /planning/path
+    objects_topic: /objdet3d_tracked
+    intersection_topic: /intersection_status
+
+    # Need detection
+    lookahead_distance_m: 35.0
+    blocked_path_distance_m: 20.0
+    stopped_object_speed_mps: 0.5   # m/s — below this = "stopped"
+    min_blockage_duration_s: 1.0    # seconds obstacle must persist before triggering
+
+    # Lane selection
+    lane_width_m: 3.5
+    allow_left_lane_change: true
+    allow_right_lane_change: true
+    require_same_direction_lane: true
+    min_target_lane_confidence: 0.6
+
+    # Gap selection
+    min_front_gap_m: 12.0
+    min_rear_gap_m: 10.0
+    min_rear_ttc_s: 4.0
+    min_side_clearance_m: 2.0
+
+    # Execution constraints (not used in shadow mode — reserved for PR 3)
+    max_lane_change_speed_mps: 8.0
+    speed_cap_during_lane_change_mps: 5.0
+    lane_change_length_m: 30.0
+    lane_change_duration_s: 4.0
+
+    # State-machine timing
+    wait_for_gap_timeout_s: 8.0
+    abort_cooldown_s: 3.0
+    complete_stabilization_time_s: 1.0
+    stale_input_timeout_s: 0.5

--- a/src/planning/navigator_lane_change/launch/lane_change_shadow.launch.py
+++ b/src/planning/navigator_lane_change/launch/lane_change_shadow.launch.py
@@ -1,0 +1,21 @@
+"""
+Shadow-mode launch for navigator_lane_change.
+Run standalone (not via launch.carla.py) for initial CARLA validation.
+"""
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+NAVIGATOR_DIR = "/navigator/"
+
+
+def generate_launch_description():
+    lane_change_node = Node(
+        package="navigator_lane_change",
+        executable="lane_change_node",
+        name="lane_change_node",
+        output="screen",
+        parameters=[NAVIGATOR_DIR + "param/lane_change_params.yaml"],
+    )
+
+    return LaunchDescription([lane_change_node])

--- a/src/planning/navigator_lane_change/navigator_lane_change/diagnostics.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/diagnostics.py
@@ -1,0 +1,95 @@
+"""
+Builds structured debug dictionaries for publication and logging.
+Every lane-change decision cycle is fully explained in the output.
+"""
+
+import json
+import time
+
+from .types import Scene, LaneChangeNeed, TargetLaneCandidate, GapAssessment, SafetyResult
+from .lane_change_state_machine import LCState
+
+
+class Diagnostics:
+    def build(
+        self,
+        state: LCState,
+        prev_state: LCState,
+        transition_reason: str,
+        scene: Scene,
+        need: LaneChangeNeed,
+        target: TargetLaneCandidate,
+        gap: GapAssessment,
+        safety: SafetyResult,
+        shadow_mode: bool,
+    ) -> dict:
+        return {
+            "timestamp": round(time.time(), 3),
+            "state": state.name,
+            "prev_state": prev_state.name,
+            "transition_reason": transition_reason,
+            "shadow_mode": shadow_mode,
+            # Need
+            "need_detected": need.needed,
+            "need_reason": need.reason,
+            "need_urgency": need.urgency,
+            "blockage_distance_m": (
+                round(need.blockage_distance_m, 2)
+                if need.blockage_distance_m != float("inf")
+                else -1
+            ),
+            "suggested_direction": need.suggested_direction,
+            # Target lane
+            "target_available": target.available,
+            "target_direction": target.direction,
+            "target_confidence": round(target.confidence, 3),
+            "target_lane_id": target.lane_id,
+            "target_lateral_offset_m": round(target.lateral_offset_m, 3),
+            "target_reason": target.reason,
+            # Gap
+            "gap_safe": gap.safe,
+            "front_gap_m": round(gap.front_gap_m, 2),
+            "rear_gap_m": round(gap.rear_gap_m, 2),
+            "rear_ttc_s": round(min(gap.rear_ttc_s, 999.0), 2),
+            "side_overlap": gap.side_overlap,
+            "gap_reason": gap.reason,
+            # Safety
+            "safety_ok": safety.safe,
+            "active_blockers": safety.blockers,
+            # Ego
+            "ego_speed_mps": round(scene.ego_speed, 2),
+            "intersection_stop": scene.intersection_stop,
+            "num_path_points": len(scene.current_path),
+            "num_objects": len(scene.nearby_objects),
+            # Topic health
+            "topic_health": {
+                "odom": scene.topic_health.odom_fresh,
+                "path": scene.topic_health.path_fresh,
+                "objects": scene.topic_health.objects_fresh,
+                "intersection": scene.topic_health.intersection_fresh,
+            },
+        }
+
+    def decision_summary(
+        self,
+        state: LCState,
+        need: LaneChangeNeed,
+        target: TargetLaneCandidate,
+        gap: GapAssessment,
+        safety: SafetyResult,
+    ) -> dict:
+        return {
+            "state": state.name,
+            "need_detected": need.needed,
+            "need_reason": need.reason,
+            "target_direction": target.direction,
+            "gap_safe": gap.safe,
+            "front_gap_m": round(gap.front_gap_m, 2),
+            "rear_gap_m": round(gap.rear_gap_m, 2),
+            "rear_ttc_s": round(min(gap.rear_ttc_s, 999.0), 2),
+            "active_blockers": safety.blockers,
+        }
+
+    @staticmethod
+    def to_json(d: dict) -> str:
+        return json.dumps(d)

--- a/src/planning/navigator_lane_change/navigator_lane_change/frenet_utils.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/frenet_utils.py
@@ -1,0 +1,91 @@
+"""
+Path-relative (Frenet) projection utilities shared across behavior modules.
+
+Coordinate convention:
+  rel_s  > 0  → ahead of ego along the path
+  rel_s  < 0  → behind ego along the path
+  lat    > 0  → LEFT of path forward direction (right-hand rule)
+  lat    < 0  → RIGHT of path forward direction
+"""
+
+import math
+from typing import List, Tuple
+
+PathPoints = List[Tuple[float, float, float]]
+
+
+def _path_tangent_at(ego_x: float, ego_y: float, path: PathPoints) -> Tuple[float, float]:
+    """
+    Return the unit forward tangent vector of the path at the point closest to
+    (ego_x, ego_y).  Falls back to the first segment if the path has only 2 points.
+    """
+    best_dist = float("inf")
+    best_seg = 0
+
+    prev = None
+    for idx, pt in enumerate(path):
+        if prev is None:
+            prev = pt
+            continue
+
+        dx = pt[0] - prev[0]
+        dy = pt[1] - prev[1]
+        seg_len = math.sqrt(dx * dx + dy * dy)
+        if seg_len < 1e-6:
+            prev = pt
+            continue
+
+        ux, uy = dx / seg_len, dy / seg_len
+        # scalar projection of ego onto segment
+        t = (ego_x - prev[0]) * ux + (ego_y - prev[1]) * uy
+        t = max(0.0, min(seg_len, t))
+        proj_x = prev[0] + t * ux
+        proj_y = prev[1] + t * uy
+        dist = math.sqrt((ego_x - proj_x) ** 2 + (ego_y - proj_y) ** 2)
+
+        if dist < best_dist:
+            best_dist = dist
+            best_seg = idx - 1  # segment index = prev index
+            best_ux, best_uy = ux, uy
+
+        prev = pt
+
+    if best_dist == float("inf"):
+        # Fall back to first segment
+        if len(path) >= 2:
+            dx = path[1][0] - path[0][0]
+            dy = path[1][1] - path[0][1]
+            seg_len = math.sqrt(dx * dx + dy * dy)
+            if seg_len > 1e-6:
+                return dx / seg_len, dy / seg_len
+        return 1.0, 0.0
+
+    return best_ux, best_uy
+
+
+def project_relative_to_ego(
+    ox: float,
+    oy: float,
+    path: PathPoints,
+    ego_x: float,
+    ego_y: float,
+) -> Tuple[float, float]:
+    """
+    Return (rel_s, lateral) of point (ox, oy) in the Frenet frame centred on
+    the ego's position along the path.
+
+    Uses the path tangent at the closest path point to ego as the local axis.
+    This is exact on straight segments and a good approximation on gentle curves.
+
+    rel_s > 0  → ahead of ego
+    lat   > 0  → left of ego heading (right-hand rule in 2D)
+    """
+    ux, uy = _path_tangent_at(ego_x, ego_y, path)
+
+    rx = ox - ego_x
+    ry = oy - ego_y
+
+    rel_s = rx * ux + ry * uy          # longitudinal: dot product
+    lat = ux * ry - uy * rx            # lateral: 2D cross product (z-component)
+
+    return rel_s, lat

--- a/src/planning/navigator_lane_change/navigator_lane_change/gap_selector.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/gap_selector.py
@@ -23,6 +23,7 @@ class GapSelector:
         min_side_clearance_m: float = 2.0,
         lookback_m: float = 40.0,
         lookahead_m: float = 60.0,
+        merging_conflict_lat_speed_mps: float = 0.4,
     ):
         self._min_front = min_front_gap_m
         self._min_rear = min_rear_gap_m
@@ -30,6 +31,7 @@ class GapSelector:
         self._side_clear = min_side_clearance_m
         self._lookback = lookback_m
         self._lookahead = lookahead_m
+        self._merge_lat_thresh = merging_conflict_lat_speed_mps
 
         # Half-width of the band considered "in target lane"
         self._lane_band = 1.6  # m from target lane center
@@ -49,6 +51,7 @@ class GapSelector:
         front_obj, front_gap = self._front(scene, ego, path, lat_off)
         rear_obj, rear_gap = self._rear(scene, ego, path, lat_off)
         side_overlap = self._side(scene, ego, path, lat_off)
+        merge_conflict = self._merging_conflict(scene, ego, path, lat_off)
 
         # Rear TTC
         if rear_obj is not None:
@@ -67,6 +70,8 @@ class GapSelector:
             fails.append(f"rear_ttc_{rear_ttc:.1f}s<{self._min_ttc}s")
         if side_overlap:
             fails.append("side_overlap")
+        if merge_conflict:
+            fails.append("merging_conflict_in_target_lane")
 
         safe = len(fails) == 0
         return GapAssessment(
@@ -75,6 +80,7 @@ class GapSelector:
             rear_gap_m=rear_gap,
             rear_ttc_s=min(rear_ttc, 999.0),
             side_overlap=side_overlap,
+            merging_conflict=merge_conflict,
             reason="gap_accepted" if safe else "; ".join(fails),
         )
 
@@ -124,6 +130,29 @@ class GapSelector:
                 continue
             if abs(lat - lat_off) < self._side_clear:
                 return True
+        return False
+
+    def _merging_conflict(self, scene: Scene, ego, path, lat_off: float) -> bool:
+        """True if a vehicle in the target lane is merging laterally toward ego's lane."""
+        from .frenet_utils import _path_tangent_at
+        ux, uy = _path_tangent_at(ego.x, ego.y, path)
+        # Lateral unit vector (positive = left of forward direction)
+        lx, ly = -uy, ux
+
+        for obj in scene.nearby_objects:
+            rel_s, lat = project_relative_to_ego(obj.x, obj.y, path, ego.x, ego.y)
+            if rel_s < -self._lookback or rel_s > self._lookahead:
+                continue
+            if abs(lat - lat_off) > self._lane_band + obj.width / 2.0:
+                continue
+            # Project object velocity onto lateral axis
+            obj_lat_vel = obj.vx * lx + obj.vy * ly
+            # Moving toward ego lane: left-lane object moving right, or right-lane object moving left
+            if lat_off > 0 and obj_lat_vel < -self._merge_lat_thresh:
+                return True
+            if lat_off < 0 and obj_lat_vel > self._merge_lat_thresh:
+                return True
+
         return False
 
     @staticmethod

--- a/src/planning/navigator_lane_change/navigator_lane_change/gap_selector.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/gap_selector.py
@@ -1,0 +1,138 @@
+"""
+Evaluates whether a safe gap exists in the target lane.
+
+Checks front gap, rear gap, rear TTC, and side overlap.
+All calculations are path-relative using Frenet projection.
+"""
+
+import math
+from typing import Optional, Tuple
+
+from .types import Scene, GapAssessment, TargetLaneCandidate, TrackedObject
+from .frenet_utils import project_relative_to_ego
+
+_EPS = 0.1  # m/s — minimum relative speed to avoid divide-by-zero
+
+
+class GapSelector:
+    def __init__(
+        self,
+        min_front_gap_m: float = 12.0,
+        min_rear_gap_m: float = 10.0,
+        min_rear_ttc_s: float = 4.0,
+        min_side_clearance_m: float = 2.0,
+        lookback_m: float = 40.0,
+        lookahead_m: float = 60.0,
+    ):
+        self._min_front = min_front_gap_m
+        self._min_rear = min_rear_gap_m
+        self._min_ttc = min_rear_ttc_s
+        self._side_clear = min_side_clearance_m
+        self._lookback = lookback_m
+        self._lookahead = lookahead_m
+
+        # Half-width of the band considered "in target lane"
+        self._lane_band = 1.6  # m from target lane center
+
+    def assess(self, scene: Scene, target: TargetLaneCandidate) -> GapAssessment:
+        if not target.available:
+            return self._unsafe("target_lane_not_available")
+        if scene.ego_pose is None:
+            return self._unsafe("no_ego_pose")
+        if len(scene.current_path) < 2:
+            return self._unsafe("no_path")
+
+        lat_off = target.lateral_offset_m
+        ego = scene.ego_pose
+        path = scene.current_path
+
+        front_obj, front_gap = self._front(scene, ego, path, lat_off)
+        rear_obj, rear_gap = self._rear(scene, ego, path, lat_off)
+        side_overlap = self._side(scene, ego, path, lat_off)
+
+        # Rear TTC
+        if rear_obj is not None:
+            closing = rear_obj.speed - scene.ego_speed
+            rear_ttc = rear_gap / max(closing, _EPS) if closing > _EPS else 999.0
+        else:
+            rear_ttc = 999.0
+
+        # Decision
+        fails = []
+        if front_gap < self._min_front:
+            fails.append(f"front_gap_{front_gap:.1f}m<{self._min_front}m")
+        if rear_gap < self._min_rear:
+            fails.append(f"rear_gap_{rear_gap:.1f}m<{self._min_rear}m")
+        if rear_ttc < self._min_ttc:
+            fails.append(f"rear_ttc_{rear_ttc:.1f}s<{self._min_ttc}s")
+        if side_overlap:
+            fails.append("side_overlap")
+
+        safe = len(fails) == 0
+        return GapAssessment(
+            safe=safe,
+            front_gap_m=front_gap,
+            rear_gap_m=rear_gap,
+            rear_ttc_s=min(rear_ttc, 999.0),
+            side_overlap=side_overlap,
+            reason="gap_accepted" if safe else "; ".join(fails),
+        )
+
+    # ------------------------------------------------------------------
+
+    def _front(
+        self, scene: Scene, ego, path, lat_off: float
+    ) -> Tuple[Optional[TrackedObject], float]:
+        best_obj = None
+        best_dist = self._lookahead
+
+        for obj in scene.nearby_objects:
+            rel_s, lat = project_relative_to_ego(obj.x, obj.y, path, ego.x, ego.y)
+            if rel_s <= 0 or rel_s > self._lookahead:
+                continue
+            if abs(lat - lat_off) > self._lane_band + obj.width / 2.0:
+                continue
+            if rel_s < best_dist:
+                best_dist = rel_s
+                best_obj = obj
+
+        return best_obj, best_dist
+
+    def _rear(
+        self, scene: Scene, ego, path, lat_off: float
+    ) -> Tuple[Optional[TrackedObject], float]:
+        best_obj = None
+        best_dist = self._lookback
+
+        for obj in scene.nearby_objects:
+            rel_s, lat = project_relative_to_ego(obj.x, obj.y, path, ego.x, ego.y)
+            if rel_s >= 0 or rel_s < -self._lookback:
+                continue
+            if abs(lat - lat_off) > self._lane_band + obj.width / 2.0:
+                continue
+            dist = abs(rel_s)
+            if dist < best_dist:
+                best_dist = dist
+                best_obj = obj
+
+        return best_obj, best_dist
+
+    def _side(self, scene: Scene, ego, path, lat_off: float) -> bool:
+        for obj in scene.nearby_objects:
+            rel_s, lat = project_relative_to_ego(obj.x, obj.y, path, ego.x, ego.y)
+            if abs(rel_s) > 8.0:  # only check objects roughly alongside ego
+                continue
+            if abs(lat - lat_off) < self._side_clear:
+                return True
+        return False
+
+    @staticmethod
+    def _unsafe(reason: str) -> GapAssessment:
+        return GapAssessment(
+            safe=False,
+            front_gap_m=0.0,
+            rear_gap_m=0.0,
+            rear_ttc_s=0.0,
+            side_overlap=False,
+            reason=reason,
+        )

--- a/src/planning/navigator_lane_change/navigator_lane_change/lane_change_node.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/lane_change_node.py
@@ -1,0 +1,235 @@
+"""
+Main ROS 2 node for navigator_lane_change (PR 1 — shadow mode).
+
+Runs at a fixed rate (default 10 Hz).
+All behavior logic lives in the imported modules; this node only handles
+ROS plumbing: subscriptions, parameters, timer, and publishers.
+"""
+
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+from nav_msgs.msg import Odometry, Path
+
+from .scene_builder import SceneBuilder
+from .need_detector import NeedDetector
+from .target_lane_selector import TargetLaneSelector
+from .gap_selector import GapSelector
+from .safety_checker import SafetyChecker
+from .lane_change_state_machine import LaneChangeStateMachine
+from .diagnostics import Diagnostics
+
+
+class LaneChangeNode(Node):
+    def __init__(self):
+        super().__init__("lane_change_node")
+
+        # ----------------------------------------------------------------
+        # Parameters
+        # ----------------------------------------------------------------
+        self.declare_parameter("loop_rate_hz", 10.0)
+        self.declare_parameter("shadow_mode", True)
+
+        # Topics
+        self.declare_parameter("odom_topic", "/gnss/odometry")
+        self.declare_parameter("path_topic", "/planning/path")
+        self.declare_parameter("objects_topic", "/objdet3d_tracked")
+        self.declare_parameter("intersection_topic", "/intersection_status")
+
+        # Need detection
+        self.declare_parameter("lookahead_distance_m", 35.0)
+        self.declare_parameter("blocked_path_distance_m", 20.0)
+        self.declare_parameter("stopped_object_speed_mps", 0.5)
+        self.declare_parameter("min_blockage_duration_s", 1.0)
+
+        # Lane selection
+        self.declare_parameter("lane_width_m", 3.5)
+        self.declare_parameter("allow_left_lane_change", True)
+        self.declare_parameter("allow_right_lane_change", True)
+        self.declare_parameter("min_target_lane_confidence", 0.6)
+
+        # Gap selection
+        self.declare_parameter("min_front_gap_m", 12.0)
+        self.declare_parameter("min_rear_gap_m", 10.0)
+        self.declare_parameter("min_rear_ttc_s", 4.0)
+        self.declare_parameter("min_side_clearance_m", 2.0)
+
+        # Safety / execution
+        self.declare_parameter("max_lane_change_speed_mps", 8.0)
+        self.declare_parameter("stale_input_timeout_s", 0.5)
+
+        # State machine timing
+        self.declare_parameter("wait_for_gap_timeout_s", 8.0)
+        self.declare_parameter("abort_cooldown_s", 3.0)
+        self.declare_parameter("complete_stabilization_time_s", 1.0)
+
+        p = self.get_parameter
+
+        self._shadow_mode: bool = p("shadow_mode").value
+        rate_hz: float = p("loop_rate_hz").value
+
+        # ----------------------------------------------------------------
+        # Components
+        # ----------------------------------------------------------------
+        self._scene = SceneBuilder(
+            stale_timeout_s=p("stale_input_timeout_s").value
+        )
+        self._need = NeedDetector(
+            lookahead_distance_m=p("lookahead_distance_m").value,
+            blocked_path_distance_m=p("blocked_path_distance_m").value,
+            stopped_object_speed_mps=p("stopped_object_speed_mps").value,
+            min_blockage_duration_s=p("min_blockage_duration_s").value,
+        )
+        self._target = TargetLaneSelector(
+            lane_width_m=p("lane_width_m").value,
+            allow_left=p("allow_left_lane_change").value,
+            allow_right=p("allow_right_lane_change").value,
+            min_confidence=p("min_target_lane_confidence").value,
+        )
+        self._gap = GapSelector(
+            min_front_gap_m=p("min_front_gap_m").value,
+            min_rear_gap_m=p("min_rear_gap_m").value,
+            min_rear_ttc_s=p("min_rear_ttc_s").value,
+            min_side_clearance_m=p("min_side_clearance_m").value,
+        )
+        self._safety = SafetyChecker(
+            stale_input_timeout_s=p("stale_input_timeout_s").value,
+            max_lane_change_speed_mps=p("max_lane_change_speed_mps").value,
+        )
+        self._sm = LaneChangeStateMachine(
+            wait_for_gap_timeout_s=p("wait_for_gap_timeout_s").value,
+            abort_cooldown_s=p("abort_cooldown_s").value,
+            complete_stabilization_time_s=p("complete_stabilization_time_s").value,
+        )
+        self._diag = Diagnostics()
+
+        # ----------------------------------------------------------------
+        # Subscriptions
+        # ----------------------------------------------------------------
+        self.create_subscription(
+            Odometry, p("odom_topic").value, self._cb_odom, 10
+        )
+        self.create_subscription(
+            Path, p("path_topic").value, self._cb_path, 10
+        )
+        self.create_subscription(
+            String, p("intersection_topic").value, self._cb_intersection, 10
+        )
+        self._subscribe_objects(p("objects_topic").value)
+
+        # ----------------------------------------------------------------
+        # Publishers (shadow-mode outputs only)
+        # ----------------------------------------------------------------
+        self._pub_state = self.create_publisher(
+            String, "/behavior/lane_change_state", 10
+        )
+        self._pub_decision = self.create_publisher(
+            String, "/behavior/lane_change_decision", 10
+        )
+        self._pub_debug = self.create_publisher(
+            String, "/behavior/lane_change_debug", 10
+        )
+
+        # ----------------------------------------------------------------
+        # Main loop timer
+        # ----------------------------------------------------------------
+        self.create_timer(1.0 / rate_hz, self._loop)
+        self.get_logger().info(
+            f"LaneChangeNode ready — shadow_mode={self._shadow_mode}, "
+            f"rate={rate_hz:.0f} Hz"
+        )
+
+    # ------------------------------------------------------------------
+    # Subscriptions
+    # ------------------------------------------------------------------
+
+    def _subscribe_objects(self, topic: str) -> None:
+        try:
+            from navigator_msgs.msg import Object3DArray  # type: ignore
+            self.create_subscription(
+                Object3DArray, topic, self._cb_objects, 10
+            )
+            self.get_logger().info(f"Objects: {topic} (Object3DArray)")
+        except ImportError:
+            self.get_logger().warn(
+                "navigator_msgs not available — object subscription skipped. "
+                "Gap and need detection will run without object data."
+            )
+
+    def _cb_odom(self, msg) -> None:
+        self._scene.update_odom(msg)
+
+    def _cb_path(self, msg) -> None:
+        self._scene.update_path(msg)
+
+    def _cb_objects(self, msg) -> None:
+        self._scene.update_objects(msg)
+
+    def _cb_intersection(self, msg) -> None:
+        self._scene.update_intersection(msg)
+
+    # ------------------------------------------------------------------
+    # Main loop
+    # ------------------------------------------------------------------
+
+    def _loop(self) -> None:
+        scene = self._scene.build()
+        need = self._need.detect(scene)
+        target = self._target.select(scene, need.suggested_direction)
+        gap = self._gap.assess(scene, target)
+        safety = self._safety.check(scene, gap)
+        state = self._sm.update(scene, need, target, gap, safety)
+
+        prev = self._sm.prev_state
+        reason = self._sm.transition_reason
+
+        # Log every state transition
+        if prev != state:
+            self.get_logger().info(
+                f"[LC] {prev.name} → {state.name}  ({reason})"
+            )
+
+        # Publish state
+        state_msg = String()
+        state_msg.data = state.name
+        self._pub_state.publish(state_msg)
+
+        # Publish compact decision summary
+        decision_msg = String()
+        decision_msg.data = Diagnostics.to_json(
+            self._diag.decision_summary(state, need, target, gap, safety)
+        )
+        self._pub_decision.publish(decision_msg)
+
+        # Publish full debug dump every cycle
+        debug_msg = String()
+        debug_msg.data = Diagnostics.to_json(
+            self._diag.build(
+                state=state,
+                prev_state=prev,
+                transition_reason=reason,
+                scene=scene,
+                need=need,
+                target=target,
+                gap=gap,
+                safety=safety,
+                shadow_mode=self._shadow_mode,
+            )
+        )
+        self._pub_debug.publish(debug_msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = LaneChangeNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/planning/navigator_lane_change/navigator_lane_change/lane_change_node.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/lane_change_node.py
@@ -35,6 +35,7 @@ class LaneChangeNode(Node):
         self.declare_parameter("path_topic", "/planning/path")
         self.declare_parameter("objects_topic", "/objdet3d_tracked")
         self.declare_parameter("intersection_topic", "/intersection_status")
+        self.declare_parameter("command_topic", "/behavior/lane_change_command")
 
         # Need detection
         self.declare_parameter("lookahead_distance_m", 35.0)
@@ -115,6 +116,9 @@ class LaneChangeNode(Node):
         self.create_subscription(
             String, p("intersection_topic").value, self._cb_intersection, 10
         )
+        self.create_subscription(
+            String, p("command_topic").value, self._cb_command, 10
+        )
         self._subscribe_objects(p("objects_topic").value)
 
         # ----------------------------------------------------------------
@@ -167,6 +171,14 @@ class LaneChangeNode(Node):
 
     def _cb_intersection(self, msg) -> None:
         self._scene.update_intersection(msg)
+
+    def _cb_command(self, msg) -> None:
+        direction = msg.data.strip().lower()
+        if direction in ("left", "right", "cancel"):
+            self._scene.update_command(direction)
+            self.get_logger().info(f"[LC] command received: {direction}")
+        else:
+            self.get_logger().warn(f"[LC] unknown command ignored: '{msg.data}'")
 
     # ------------------------------------------------------------------
     # Main loop

--- a/src/planning/navigator_lane_change/navigator_lane_change/lane_change_state_machine.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/lane_change_state_machine.py
@@ -1,0 +1,224 @@
+"""
+Lane-change behavior state machine.
+
+States follow the spec in lane_change_integration_plan.md §6.7.
+Every transition is logged with a reason string for bag-based debugging.
+"""
+
+import time
+from enum import Enum, auto
+
+from .types import Scene, LaneChangeNeed, TargetLaneCandidate, GapAssessment, SafetyResult
+
+
+class LCState(Enum):
+    IDLE = auto()
+    PREPARE_LANE_CHANGE = auto()
+    CHECK_TARGET_LANE = auto()
+    FIND_GAP = auto()
+    WAIT_FOR_GAP = auto()
+    COMMIT_LANE_CHANGE = auto()
+    EXECUTE_LANE_CHANGE = auto()
+    COMPLETE_LANE_CHANGE = auto()
+    ABORT_LANE_CHANGE = auto()
+    ROUTE_BLOCKED = auto()
+    FAULT = auto()
+
+
+class LaneChangeStateMachine:
+    def __init__(
+        self,
+        wait_for_gap_timeout_s: float = 8.0,
+        abort_cooldown_s: float = 3.0,
+        complete_stabilization_time_s: float = 1.0,
+    ):
+        self._gap_timeout = wait_for_gap_timeout_s
+        self._abort_cd = abort_cooldown_s
+        self._complete_stab = complete_stabilization_time_s
+
+        self.state = LCState.IDLE
+        self._prev_state = LCState.IDLE
+        self._reason = "initialized"
+        self._entry_time = time.time()
+
+    @property
+    def prev_state(self) -> LCState:
+        return self._prev_state
+
+    @property
+    def transition_reason(self) -> str:
+        return self._reason
+
+    def update(
+        self,
+        scene: Scene,
+        need: LaneChangeNeed,
+        target: TargetLaneCandidate,
+        gap: GapAssessment,
+        safety: SafetyResult,
+    ) -> LCState:
+
+        # Hard-fault: required inputs stale
+        if not scene.topic_health.odom_fresh or not scene.topic_health.path_fresh:
+            if self.state != LCState.FAULT:
+                self._go(LCState.FAULT, "required_inputs_stale")
+            return self.state
+
+        state = self.state
+
+        if state == LCState.FAULT:
+            self._handle_fault(scene)
+
+        elif state == LCState.ABORT_LANE_CHANGE:
+            self._handle_abort(need)
+
+        elif state == LCState.COMPLETE_LANE_CHANGE:
+            self._handle_complete()
+
+        elif state == LCState.ROUTE_BLOCKED:
+            self._handle_route_blocked(need, target)
+
+        elif state == LCState.IDLE:
+            if need.needed:
+                self._go(LCState.PREPARE_LANE_CHANGE, need.reason)
+
+        elif state == LCState.PREPARE_LANE_CHANGE:
+            self._handle_prepare(need, target, safety)
+
+        elif state == LCState.CHECK_TARGET_LANE:
+            self._handle_check(need, target)
+
+        elif state == LCState.FIND_GAP:
+            self._handle_find_gap(need, gap, safety)
+
+        elif state == LCState.WAIT_FOR_GAP:
+            self._handle_wait_for_gap(need, gap, safety)
+
+        elif state == LCState.COMMIT_LANE_CHANGE:
+            self._handle_commit(safety)
+
+        elif state == LCState.EXECUTE_LANE_CHANGE:
+            self._handle_execute(safety)
+
+        return self.state
+
+    # ------------------------------------------------------------------
+    # Per-state handlers
+    # ------------------------------------------------------------------
+
+    def _handle_fault(self, scene: Scene):
+        if scene.topic_health.odom_fresh and scene.topic_health.path_fresh:
+            self._go(LCState.IDLE, "inputs_recovered")
+
+    def _handle_abort(self, need: LaneChangeNeed):
+        if time.time() - self._entry_time >= self._abort_cd:
+            if not need.needed:
+                self._go(LCState.IDLE, "abort_cooldown_path_clear")
+            else:
+                self._go(LCState.ROUTE_BLOCKED, "abort_cooldown_still_blocked")
+
+    def _handle_complete(self):
+        if time.time() - self._entry_time >= self._complete_stab:
+            self._go(LCState.IDLE, "stabilization_complete")
+
+    def _handle_route_blocked(self, need: LaneChangeNeed, target: TargetLaneCandidate):
+        if not need.needed:
+            self._go(LCState.IDLE, "blockage_cleared")
+        elif target.available:
+            self._go(LCState.PREPARE_LANE_CHANGE, "new_candidate_appeared")
+
+    def _handle_prepare(
+        self,
+        need: LaneChangeNeed,
+        target: TargetLaneCandidate,
+        safety: SafetyResult,
+    ):
+        if not need.needed:
+            self._go(LCState.IDLE, "need_cleared")
+        elif self._has_hard_blocker(safety):
+            self._go(LCState.FAULT, f"hard_safety_blocker:{safety.blockers}")
+        elif target.available:
+            self._go(LCState.CHECK_TARGET_LANE, f"candidate_{target.direction}")
+        else:
+            self._go(LCState.ROUTE_BLOCKED, "no_adjacent_lane_available")
+
+    def _handle_check(self, need: LaneChangeNeed, target: TargetLaneCandidate):
+        if not need.needed:
+            self._go(LCState.IDLE, "need_cleared")
+        elif not target.available:
+            self._go(LCState.ABORT_LANE_CHANGE, "target_lane_became_invalid")
+        else:
+            self._go(LCState.FIND_GAP, "target_lane_valid")
+
+    def _handle_find_gap(
+        self,
+        need: LaneChangeNeed,
+        gap: GapAssessment,
+        safety: SafetyResult,
+    ):
+        if not need.needed:
+            self._go(LCState.IDLE, "need_cleared")
+        elif self._has_hard_blocker(safety):
+            self._go(LCState.ABORT_LANE_CHANGE, f"hard_safety:{safety.blockers}")
+        elif gap.safe and safety.safe:
+            self._go(LCState.COMMIT_LANE_CHANGE, "safe_gap_found")
+        else:
+            elapsed = time.time() - self._entry_time
+            if elapsed < self._gap_timeout:
+                self._go(LCState.WAIT_FOR_GAP, f"gap_unsafe_waiting:{gap.reason}")
+            else:
+                self._go(LCState.ROUTE_BLOCKED, "find_gap_timeout")
+
+    def _handle_wait_for_gap(
+        self,
+        need: LaneChangeNeed,
+        gap: GapAssessment,
+        safety: SafetyResult,
+    ):
+        if not need.needed:
+            self._go(LCState.IDLE, "need_cleared")
+        elif gap.safe and safety.safe:
+            self._go(LCState.COMMIT_LANE_CHANGE, "gap_opened")
+        elif time.time() - self._entry_time > self._gap_timeout:
+            self._go(LCState.ABORT_LANE_CHANGE, "wait_for_gap_timeout")
+
+    def _handle_commit(self, safety: SafetyResult):
+        if not safety.safe:
+            self._go(LCState.ABORT_LANE_CHANGE, f"safety_failed_at_commit:{safety.blockers}")
+        else:
+            # In shadow mode this immediately moves to EXECUTE (no real actuation).
+            # In execution mode the node checks path validity here before transitioning.
+            self._go(LCState.EXECUTE_LANE_CHANGE, "committed")
+
+    def _handle_execute(self, safety: SafetyResult):
+        if not safety.safe:
+            self._go(LCState.ABORT_LANE_CHANGE, f"safety_failed_during_execute:{safety.blockers}")
+        # Completion is triggered externally via mark_complete()
+
+    # ------------------------------------------------------------------
+    # External triggers
+    # ------------------------------------------------------------------
+
+    def mark_complete(self):
+        self._go(LCState.COMPLETE_LANE_CHANGE, "target_lane_reached")
+
+    def force_abort(self, reason: str):
+        self._go(LCState.ABORT_LANE_CHANGE, reason)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _go(self, new_state: LCState, reason: str):
+        if new_state == self.state:
+            return
+        self._prev_state = self.state
+        self.state = new_state
+        self._reason = reason
+        self._entry_time = time.time()
+
+    @staticmethod
+    def _has_hard_blocker(safety: SafetyResult) -> bool:
+        """True when blockers exist beyond just gap unsafety."""
+        hard = [b for b in safety.blockers if not b.startswith("gap_unsafe")]
+        return len(hard) > 0

--- a/src/planning/navigator_lane_change/navigator_lane_change/lane_change_state_machine.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/lane_change_state_machine.py
@@ -58,10 +58,12 @@ class LaneChangeStateMachine:
         safety: SafetyResult,
     ) -> LCState:
 
-        # Hard-fault: required inputs stale
-        if not scene.topic_health.odom_fresh or not scene.topic_health.path_fresh:
+        # Hard-fault: odometry is safety-critical — we cannot know where we are.
+        # Missing path is handled gracefully by need_detector (returns no_need),
+        # so the node stays IDLE rather than faulting when the planner is offline.
+        if not scene.topic_health.odom_fresh:
             if self.state != LCState.FAULT:
-                self._go(LCState.FAULT, "required_inputs_stale")
+                self._go(LCState.FAULT, "odom_stale")
             return self.state
 
         state = self.state

--- a/src/planning/navigator_lane_change/navigator_lane_change/need_detector.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/need_detector.py
@@ -40,6 +40,19 @@ class NeedDetector:
             self._reset()
             return self._no("intersection_stop_active")
 
+        # Explicit operator / planner command takes priority over obstacle detection.
+        if scene.commanded_direction in ("left", "right"):
+            return LaneChangeNeed(
+                needed=True,
+                reason="commanded_lane_change",
+                urgency="normal",
+                blockage_distance_m=float("inf"),
+                suggested_direction=scene.commanded_direction,
+            )
+        if scene.commanded_direction == "cancel":
+            self._reset()
+            return self._no("command_cancel")
+
         blocking, dist = self._find_blocking_object(scene)
 
         if blocking is None:

--- a/src/planning/navigator_lane_change/navigator_lane_change/need_detector.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/need_detector.py
@@ -1,0 +1,115 @@
+"""
+Determines whether a lane change should be considered.
+
+Triggers on:
+  - Stopped / slow obstacle inside the path corridor ahead of ego
+  - Obstacle blocked for at least min_blockage_duration_s
+"""
+
+import time
+from typing import Optional, Tuple
+
+from .types import Scene, LaneChangeNeed, TrackedObject
+from .frenet_utils import project_relative_to_ego
+
+
+class NeedDetector:
+    def __init__(
+        self,
+        lookahead_distance_m: float = 35.0,
+        blocked_path_distance_m: float = 20.0,
+        stopped_object_speed_mps: float = 0.5,
+        min_blockage_duration_s: float = 1.0,
+        path_corridor_half_width_m: float = 1.8,
+    ):
+        self._lookahead = lookahead_distance_m
+        self._blocked_dist = blocked_path_distance_m
+        self._stopped_spd = stopped_object_speed_mps
+        self._min_duration = min_blockage_duration_s
+        self._corridor_hw = path_corridor_half_width_m
+
+        self._blockage_first_seen: Optional[float] = None
+        self._blocking_id: Optional[str] = None
+
+    def detect(self, scene: Scene) -> LaneChangeNeed:
+        if scene.ego_pose is None:
+            return self._no("no_odometry")
+        if len(scene.current_path) < 2:
+            return self._no("no_path")
+        if scene.intersection_stop:
+            self._reset()
+            return self._no("intersection_stop_active")
+
+        blocking, dist = self._find_blocking_object(scene)
+
+        if blocking is None:
+            self._reset()
+            return self._no("path_clear")
+
+        # Require the blockage to persist before triggering
+        if self._blocking_id != blocking.object_id:
+            self._blockage_first_seen = time.time()
+            self._blocking_id = blocking.object_id
+
+        elapsed = time.time() - self._blockage_first_seen
+        if elapsed < self._min_duration:
+            return self._no("blockage_too_brief")
+
+        direction = "left"  # TargetLaneSelector will override with best option
+        return LaneChangeNeed(
+            needed=True,
+            reason="stopped_object_blocking_path",
+            urgency="normal",
+            blockage_distance_m=dist,
+            suggested_direction=direction,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _find_blocking_object(
+        self, scene: Scene
+    ) -> Tuple[Optional[TrackedObject], float]:
+        ego = scene.ego_pose
+        path = scene.current_path
+        best_obj: Optional[TrackedObject] = None
+        best_dist = float("inf")
+
+        for obj in scene.nearby_objects:
+            if obj.speed > self._stopped_spd:
+                continue  # Moving vehicle — ACC handles it
+
+            rel_s, lat = project_relative_to_ego(
+                obj.x, obj.y, path, ego.x, ego.y
+            )
+
+            if rel_s <= 0.5:
+                continue  # At or behind ego
+            if rel_s > self._lookahead:
+                continue  # Too far ahead to act now
+
+            # Account for object's own width in corridor check
+            half_obj_w = obj.width / 2.0
+            if abs(lat) > self._corridor_hw + half_obj_w:
+                continue  # Outside lane corridor
+
+            if rel_s < best_dist:
+                best_dist = rel_s
+                best_obj = obj
+
+        return best_obj, best_dist
+
+    def _reset(self):
+        self._blockage_first_seen = None
+        self._blocking_id = None
+
+    @staticmethod
+    def _no(reason: str) -> LaneChangeNeed:
+        return LaneChangeNeed(
+            needed=False,
+            reason=reason,
+            urgency="none",
+            blockage_distance_m=float("inf"),
+            suggested_direction="none",
+        )

--- a/src/planning/navigator_lane_change/navigator_lane_change/safety_checker.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/safety_checker.py
@@ -1,0 +1,38 @@
+"""
+Final conservative safety gate — runs before commit and during execution.
+Returns a SafetyResult with a list of all active blockers.
+"""
+
+from .types import Scene, GapAssessment, SafetyResult
+
+
+class SafetyChecker:
+    def __init__(
+        self,
+        stale_input_timeout_s: float = 0.5,
+        max_lane_change_speed_mps: float = 8.0,
+    ):
+        self._stale = stale_input_timeout_s
+        self._max_speed = max_lane_change_speed_mps
+
+    def check(self, scene: Scene, gap: GapAssessment) -> SafetyResult:
+        blockers = []
+
+        if not scene.topic_health.odom_fresh:
+            blockers.append("odom_stale")
+        if not scene.topic_health.path_fresh:
+            blockers.append("path_stale")
+        if scene.ego_pose is None:
+            blockers.append("ego_pose_missing")
+        if len(scene.current_path) < 2:
+            blockers.append("path_missing_or_empty")
+        if scene.ego_speed > self._max_speed:
+            blockers.append(
+                f"ego_speed_{scene.ego_speed:.1f}_above_max_{self._max_speed}"
+            )
+        if scene.intersection_stop:
+            blockers.append("intersection_stop_active")
+        if not gap.safe:
+            blockers.append(f"gap_unsafe:{gap.reason}")
+
+        return SafetyResult(safe=len(blockers) == 0, blockers=blockers)

--- a/src/planning/navigator_lane_change/navigator_lane_change/safety_checker.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/safety_checker.py
@@ -20,12 +20,12 @@ class SafetyChecker:
 
         if not scene.topic_health.odom_fresh:
             blockers.append("odom_stale")
-        if not scene.topic_health.path_fresh:
-            blockers.append("path_stale")
         if scene.ego_pose is None:
             blockers.append("ego_pose_missing")
+        # path_missing keeps the node in IDLE via need_detector — not a safety fault.
+        # Only block execution if path disappears while a maneuver is already active.
         if len(scene.current_path) < 2:
-            blockers.append("path_missing_or_empty")
+            blockers.append("path_missing_during_execution")
         if scene.ego_speed > self._max_speed:
             blockers.append(
                 f"ego_speed_{scene.ego_speed:.1f}_above_max_{self._max_speed}"

--- a/src/planning/navigator_lane_change/navigator_lane_change/scene_builder.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/scene_builder.py
@@ -1,0 +1,164 @@
+"""
+Converts raw ROS topic data into a normalized Scene for behavior logic.
+All behavior modules consume Scene, not raw ROS messages.
+"""
+
+import math
+import time
+from typing import Optional
+
+from .types import (
+    Scene, EgoPose, TrackedObject, TopicHealth,
+)
+
+
+class SceneBuilder:
+    def __init__(self, stale_timeout_s: float = 0.5):
+        self._stale = stale_timeout_s
+
+        self._odom = None
+        self._path = None
+        self._objects = None
+        self._intersection = None
+
+        self._t_odom = 0.0
+        self._t_path = 0.0
+        self._t_objects = 0.0
+        self._t_intersection = 0.0
+
+    # ------------------------------------------------------------------
+    # ROS callback handlers — store latest message + receipt timestamp
+    # ------------------------------------------------------------------
+
+    def update_odom(self, msg) -> None:
+        self._odom = msg
+        self._t_odom = time.time()
+
+    def update_path(self, msg) -> None:
+        self._path = msg
+        self._t_path = time.time()
+
+    def update_objects(self, msg) -> None:
+        self._objects = msg
+        self._t_objects = time.time()
+
+    def update_intersection(self, msg) -> None:
+        self._intersection = msg
+        self._t_intersection = time.time()
+
+    # ------------------------------------------------------------------
+    # Build Scene
+    # ------------------------------------------------------------------
+
+    def build(self) -> Scene:
+        now = time.time()
+
+        health = TopicHealth(
+            odom_fresh=(now - self._t_odom) < self._stale,
+            path_fresh=(now - self._t_path) < self._stale,
+            # Objects and intersection can arrive slower — allow 4× timeout
+            objects_fresh=(now - self._t_objects) < self._stale * 4,
+            intersection_fresh=(now - self._t_intersection) < self._stale * 4,
+        )
+
+        ego_pose: Optional[EgoPose] = None
+        ego_speed = 0.0
+        ego_heading = 0.0
+        if health.odom_fresh and self._odom is not None:
+            ego_pose, ego_speed, ego_heading = self._parse_odom(self._odom)
+
+        path = []
+        if health.path_fresh and self._path is not None:
+            path = self._parse_path(self._path)
+
+        objects = []
+        if self._objects is not None:
+            objects = self._parse_objects(self._objects)
+
+        intersection_stop = False
+        if self._intersection is not None and health.intersection_fresh:
+            intersection_stop = self._parse_intersection(self._intersection)
+
+        return Scene(
+            stamp=now,
+            ego_pose=ego_pose,
+            ego_speed=ego_speed,
+            ego_heading=ego_heading,
+            current_path=path,
+            nearby_objects=objects,
+            intersection_stop=intersection_stop,
+            topic_health=health,
+        )
+
+    # ------------------------------------------------------------------
+    # Parsers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_odom(msg):
+        pos = msg.pose.pose.position
+        ori = msg.pose.pose.orientation
+        lin = msg.twist.twist.linear
+
+        yaw = SceneBuilder._quat_to_yaw(ori.x, ori.y, ori.z, ori.w)
+        speed = math.sqrt(lin.x ** 2 + lin.y ** 2)
+        pose = EgoPose(x=pos.x, y=pos.y, z=pos.z, yaw=yaw)
+        return pose, speed, yaw
+
+    @staticmethod
+    def _parse_path(msg):
+        pts = []
+        for ps in msg.poses:
+            p = ps.pose.position
+            pts.append((p.x, p.y, p.z))
+        return pts
+
+    @staticmethod
+    def _parse_objects(msg):
+        objs = []
+        try:
+            for obj in msg.objects:
+                try:
+                    pos = obj.pose.position
+                    vel = getattr(obj, "velocity", None)
+                    dims = getattr(obj, "dimensions", None)
+
+                    vx = vel.linear.x if vel and hasattr(vel, "linear") else (vel.x if vel else 0.0)
+                    vy = vel.linear.y if vel and hasattr(vel, "linear") else (vel.y if vel else 0.0)
+
+                    length = dims.x if dims else 4.5
+                    width = dims.y if dims else 2.0
+                    height = dims.z if dims else 1.5
+
+                    obj_id = str(getattr(obj, "id", "?"))
+                    cls = str(getattr(obj, "classification", "unknown"))
+                    conf = float(getattr(obj, "confidence", 1.0))
+
+                    objs.append(TrackedObject(
+                        object_id=obj_id,
+                        classification=cls,
+                        x=pos.x, y=pos.y, z=pos.z,
+                        vx=vx, vy=vy,
+                        length=length, width=width, height=height,
+                        confidence=conf,
+                    ))
+                except Exception:
+                    continue
+        except Exception:
+            pass
+        return objs
+
+    @staticmethod
+    def _parse_intersection(msg) -> bool:
+        # navigator_msgs/IntersectionStatus: status field — non-zero means stop required
+        try:
+            status = getattr(msg, "status", 0)
+            return int(status) > 0
+        except Exception:
+            return False
+
+    @staticmethod
+    def _quat_to_yaw(x, y, z, w) -> float:
+        siny = 2.0 * (w * z + x * y)
+        cosy = 1.0 - 2.0 * (y * y + z * z)
+        return math.atan2(siny, cosy)

--- a/src/planning/navigator_lane_change/navigator_lane_change/scene_builder.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/scene_builder.py
@@ -26,6 +26,10 @@ class SceneBuilder:
         self._t_objects = 0.0
         self._t_intersection = 0.0
 
+        self._commanded_direction = "none"
+        self._t_command = 0.0
+        self._command_timeout_s = 30.0
+
     # ------------------------------------------------------------------
     # ROS callback handlers — store latest message + receipt timestamp
     # ------------------------------------------------------------------
@@ -46,12 +50,23 @@ class SceneBuilder:
         self._intersection = msg
         self._t_intersection = time.time()
 
+    def update_command(self, direction: str) -> None:
+        """Store an operator or planner lane-change command. Expires after command_timeout_s."""
+        self._commanded_direction = direction
+        self._t_command = time.time()
+
     # ------------------------------------------------------------------
     # Build Scene
     # ------------------------------------------------------------------
 
     def build(self) -> Scene:
         now = time.time()
+
+        # Command expires after timeout to prevent stale commands driving behaviour.
+        commanded = self._commanded_direction
+        if commanded != "none" and (now - self._t_command) > self._command_timeout_s:
+            commanded = "none"
+            self._commanded_direction = "none"
 
         health = TopicHealth(
             odom_fresh=(now - self._t_odom) < self._stale,
@@ -88,6 +103,7 @@ class SceneBuilder:
             nearby_objects=objects,
             intersection_stop=intersection_stop,
             topic_health=health,
+            commanded_direction=commanded,
         )
 
     # ------------------------------------------------------------------

--- a/src/planning/navigator_lane_change/navigator_lane_change/target_lane_selector.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/target_lane_selector.py
@@ -1,0 +1,122 @@
+"""
+Chooses the best adjacent candidate lane for a lane change.
+
+Priority (obstacle-bypass mode, V1):
+  1. Direction suggested by NeedDetector
+  2. Opposite adjacent direction
+  Reject if too many objects in that lateral band.
+"""
+
+import math
+from typing import List
+
+from .types import Scene, TargetLaneCandidate, TrackedObject
+from .frenet_utils import project_relative_to_ego
+
+
+class TargetLaneSelector:
+    def __init__(
+        self,
+        lane_width_m: float = 3.5,
+        allow_left: bool = True,
+        allow_right: bool = True,
+        require_same_direction: bool = True,
+        min_confidence: float = 0.6,
+        scan_range_ahead_m: float = 60.0,
+        scan_range_behind_m: float = 30.0,
+    ):
+        self._lane_w = lane_width_m
+        self._allow_left = allow_left
+        self._allow_right = allow_right
+        self._min_conf = min_confidence
+        self._scan_ahead = scan_range_ahead_m
+        self._scan_behind = scan_range_behind_m
+
+    def select(
+        self, scene: Scene, suggested_direction: str = "left"
+    ) -> TargetLaneCandidate:
+        if scene.ego_pose is None:
+            return self._unavail("no_ego_pose")
+        if len(scene.current_path) < 2:
+            return self._unavail("no_path")
+
+        ordered = self._direction_order(suggested_direction)
+        if not ordered:
+            return self._unavail("no_direction_allowed")
+
+        for direction in ordered:
+            candidate = self._evaluate(scene, direction)
+            if candidate.available and candidate.confidence >= self._min_conf:
+                return candidate
+
+        return self._unavail("no_adjacent_lane_above_confidence_threshold")
+
+    # ------------------------------------------------------------------
+
+    def _direction_order(self, suggested: str) -> List[str]:
+        directions = []
+        if suggested == "left":
+            if self._allow_left:
+                directions.append("left")
+            if self._allow_right:
+                directions.append("right")
+        else:
+            if self._allow_right:
+                directions.append("right")
+            if self._allow_left:
+                directions.append("left")
+        return directions
+
+    def _evaluate(self, scene: Scene, direction: str) -> TargetLaneCandidate:
+        lateral_offset = self._lane_w if direction == "left" else -self._lane_w
+        nearby = self._objects_near_target_lane(scene, lateral_offset)
+
+        # Confidence degrades with object count in the target lane band
+        if len(nearby) == 0:
+            confidence = 0.88
+            reason = f"{direction}_adjacent_clear"
+        elif len(nearby) <= 2:
+            confidence = 0.72
+            reason = f"{direction}_adjacent_sparse_{len(nearby)}_objects"
+        else:
+            confidence = 0.30
+            reason = f"{direction}_adjacent_dense_{len(nearby)}_objects"
+
+        return TargetLaneCandidate(
+            available=True,
+            direction=direction,
+            lane_id=f"adjacent_{direction}",
+            confidence=confidence,
+            lateral_offset_m=lateral_offset,
+            reason=reason,
+        )
+
+    def _objects_near_target_lane(
+        self, scene: Scene, lateral_offset: float
+    ) -> List[TrackedObject]:
+        ego = scene.ego_pose
+        path = scene.current_path
+        half_band = self._lane_w / 2.0
+        result = []
+
+        for obj in scene.nearby_objects:
+            rel_s, lat = project_relative_to_ego(
+                obj.x, obj.y, path, ego.x, ego.y
+            )
+            if rel_s < -self._scan_behind or rel_s > self._scan_ahead:
+                continue
+            if abs(lat - lateral_offset) <= half_band:
+                result.append(obj)
+
+        return result
+
+    @staticmethod
+    def _unavail(reason: str) -> TargetLaneCandidate:
+        return TargetLaneCandidate(
+            available=False,
+            direction="none",
+            lane_id="",
+            confidence=0.0,
+            lateral_offset_m=0.0,
+            reason=reason,
+        )

--- a/src/planning/navigator_lane_change/navigator_lane_change/types.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/types.py
@@ -48,6 +48,7 @@ class Scene:
     nearby_objects: List[TrackedObject]
     intersection_stop: bool
     topic_health: TopicHealth
+    commanded_direction: str = "none"  # "left" | "right" | "cancel" | "none"
 
 
 @dataclass
@@ -77,6 +78,7 @@ class GapAssessment:
     rear_ttc_s: float
     side_overlap: bool
     reason: str
+    merging_conflict: bool = False
 
 
 @dataclass

--- a/src/planning/navigator_lane_change/navigator_lane_change/types.py
+++ b/src/planning/navigator_lane_change/navigator_lane_change/types.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+import math
+
+
+@dataclass
+class EgoPose:
+    x: float
+    y: float
+    z: float
+    yaw: float  # radians
+
+
+@dataclass
+class TrackedObject:
+    object_id: str
+    classification: str
+    x: float
+    y: float
+    z: float
+    vx: float
+    vy: float
+    length: float
+    width: float
+    height: float
+    confidence: float = 1.0
+
+    @property
+    def speed(self) -> float:
+        return math.sqrt(self.vx ** 2 + self.vy ** 2)
+
+
+@dataclass
+class TopicHealth:
+    odom_fresh: bool = False
+    path_fresh: bool = False
+    objects_fresh: bool = False
+    intersection_fresh: bool = False
+
+
+@dataclass
+class Scene:
+    stamp: float
+    ego_pose: Optional[EgoPose]
+    ego_speed: float
+    ego_heading: float
+    current_path: List[Tuple[float, float, float]]  # (x, y, z)
+    nearby_objects: List[TrackedObject]
+    intersection_stop: bool
+    topic_health: TopicHealth
+
+
+@dataclass
+class LaneChangeNeed:
+    needed: bool
+    reason: str
+    urgency: str  # "none" | "normal" | "high"
+    blockage_distance_m: float
+    suggested_direction: str  # "left" | "right" | "none"
+
+
+@dataclass
+class TargetLaneCandidate:
+    available: bool
+    direction: str  # "left" | "right" | "none"
+    lane_id: str
+    confidence: float
+    lateral_offset_m: float
+    reason: str
+
+
+@dataclass
+class GapAssessment:
+    safe: bool
+    front_gap_m: float
+    rear_gap_m: float
+    rear_ttc_s: float
+    side_overlap: bool
+    reason: str
+
+
+@dataclass
+class SafetyResult:
+    safe: bool
+    blockers: List[str] = field(default_factory=list)

--- a/src/planning/navigator_lane_change/package.xml
+++ b/src/planning/navigator_lane_change/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>navigator_lane_change</name>
+  <version>0.1.0</version>
+  <description>
+    Route-aware lane-change and obstacle-bypass behavior module for Navigator.
+    PR 1: shadow-mode decision node (no vehicle control).
+  </description>
+  <maintainer email="team@nova-utd.org">Nova UTD</maintainer>
+  <license>MIT</license>
+
+  <depend>rclpy</depend>
+  <depend>std_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>geometry_msgs</depend>
+
+  <!-- Optional: navigator_msgs for Object3DArray -->
+  <exec_depend condition="$NAVIGATOR_MSGS_AVAILABLE">navigator_msgs</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/src/planning/navigator_lane_change/package.xml
+++ b/src/planning/navigator_lane_change/package.xml
@@ -15,8 +15,7 @@
   <depend>nav_msgs</depend>
   <depend>geometry_msgs</depend>
 
-  <!-- Optional: navigator_msgs for Object3DArray -->
-  <exec_depend condition="$NAVIGATOR_MSGS_AVAILABLE">navigator_msgs</exec_depend>
+  <exec_depend>navigator_msgs</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/src/planning/navigator_lane_change/param/lane_change_params.yaml
+++ b/src/planning/navigator_lane_change/param/lane_change_params.yaml
@@ -1,0 +1,41 @@
+lane_change_node:
+  ros__parameters:
+    loop_rate_hz: 10.0
+    shadow_mode: true           # Set false only after CARLA shadow validation
+
+    # Topics — match current Navigator stack names
+    odom_topic: /gnss/odometry
+    path_topic: /planning/path
+    objects_topic: /objdet3d_tracked
+    intersection_topic: /intersection_status
+
+    # Need detection
+    lookahead_distance_m: 35.0
+    blocked_path_distance_m: 20.0
+    stopped_object_speed_mps: 0.5   # m/s — below this = "stopped"
+    min_blockage_duration_s: 1.0    # seconds obstacle must persist before triggering
+
+    # Lane selection
+    lane_width_m: 3.5
+    allow_left_lane_change: true
+    allow_right_lane_change: true
+    require_same_direction_lane: true
+    min_target_lane_confidence: 0.6
+
+    # Gap selection
+    min_front_gap_m: 12.0
+    min_rear_gap_m: 10.0
+    min_rear_ttc_s: 4.0
+    min_side_clearance_m: 2.0
+
+    # Execution constraints (not used in shadow mode — reserved for PR 3)
+    max_lane_change_speed_mps: 8.0
+    speed_cap_during_lane_change_mps: 5.0
+    lane_change_length_m: 30.0
+    lane_change_duration_s: 4.0
+
+    # State-machine timing
+    wait_for_gap_timeout_s: 8.0
+    abort_cooldown_s: 3.0
+    complete_stabilization_time_s: 1.0
+    stale_input_timeout_s: 0.5

--- a/src/planning/navigator_lane_change/setup.cfg
+++ b/src/planning/navigator_lane_change/setup.cfg
@@ -1,0 +1,5 @@
+[develop]
+script_dir=$base/lib/navigator_lane_change
+
+[install]
+install_scripts=$base/lib/navigator_lane_change

--- a/src/planning/navigator_lane_change/setup.py
+++ b/src/planning/navigator_lane_change/setup.py
@@ -1,0 +1,28 @@
+from setuptools import setup, find_packages
+import os
+from glob import glob
+
+package_name = "navigator_lane_change"
+
+setup(
+    name=package_name,
+    version="0.1.0",
+    packages=find_packages(exclude=["test"]),
+    data_files=[
+        ("share/ament_index/resource_index/packages", [f"resource/{package_name}"]),
+        (f"share/{package_name}", ["package.xml"]),
+        (f"share/{package_name}/launch", glob("launch/*.py")),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="Nova UTD",
+    maintainer_email="team@nova-utd.org",
+    description="Lane-change behavior module for Navigator (shadow mode)",
+    license="MIT",
+    tests_require=["pytest"],
+    entry_points={
+        "console_scripts": [
+            f"lane_change_node = {package_name}.lane_change_node:main",
+        ],
+    },
+)

--- a/src/planning/navigator_lane_change/test/test_gap_selector.py
+++ b/src/planning/navigator_lane_change/test/test_gap_selector.py
@@ -1,0 +1,113 @@
+"""Unit tests for GapSelector — no ROS required."""
+
+import time
+import pytest
+from navigator_lane_change.gap_selector import GapSelector
+from navigator_lane_change.types import (
+    Scene, EgoPose, TrackedObject, TopicHealth, TargetLaneCandidate,
+)
+
+
+def make_scene(objects=None, ego_speed=3.0):
+    path = [(float(i), 0.0, 0.0) for i in range(0, 100, 2)]
+    return Scene(
+        stamp=time.time(),
+        ego_pose=EgoPose(x=0.0, y=0.0, z=0.0, yaw=0.0),
+        ego_speed=ego_speed,
+        ego_heading=0.0,
+        current_path=path,
+        nearby_objects=objects or [],
+        intersection_stop=False,
+        topic_health=TopicHealth(
+            odom_fresh=True, path_fresh=True,
+            objects_fresh=True, intersection_fresh=True,
+        ),
+    )
+
+
+def left_target():
+    return TargetLaneCandidate(
+        available=True, direction="left",
+        lane_id="adjacent_left", confidence=0.85,
+        lateral_offset_m=3.5, reason="clear",
+    )
+
+
+def vehicle(x, y=3.5, vx=0.0, vy=0.0):
+    return TrackedObject(
+        object_id="v1", classification="vehicle",
+        x=x, y=y, z=0.0,
+        vx=vx, vy=vy,
+        length=4.5, width=2.0, height=1.5,
+    )
+
+
+class TestGapSelector:
+    def test_empty_target_lane_is_safe(self):
+        gs = GapSelector()
+        scene = make_scene(objects=[])
+        result = gs.assess(scene, left_target())
+        assert result.safe
+
+    def test_front_gap_too_small_rejects(self):
+        gs = GapSelector(min_front_gap_m=12.0)
+        # Vehicle in target lane 8 m ahead
+        scene = make_scene(objects=[vehicle(x=8.0, y=3.5)])
+        result = gs.assess(scene, left_target())
+        assert not result.safe
+        assert "front_gap" in result.reason
+
+    def test_rear_gap_too_small_rejects(self):
+        gs = GapSelector(min_rear_gap_m=10.0)
+        # Vehicle 5 m behind in target lane
+        scene = make_scene(objects=[vehicle(x=-5.0, y=3.5)])
+        result = gs.assess(scene, left_target())
+        assert not result.safe
+        assert "rear_gap" in result.reason
+
+    def test_rear_ttc_too_low_rejects(self):
+        gs = GapSelector(min_rear_gap_m=10.0, min_rear_ttc_s=4.0)
+        # Vehicle 15 m behind but closing at 10 m/s → TTC = 1.5 s
+        scene = make_scene(
+            objects=[vehicle(x=-15.0, y=3.5, vx=10.0)],  # approaching fast
+            ego_speed=3.0,
+        )
+        result = gs.assess(scene, left_target())
+        assert not result.safe
+        assert "rear_ttc" in result.reason
+
+    def test_large_front_and_rear_gap_is_safe(self):
+        gs = GapSelector(min_front_gap_m=12.0, min_rear_gap_m=10.0, min_rear_ttc_s=4.0)
+        objs = [
+            vehicle(x=30.0, y=3.5),   # front: 30 m ahead
+            vehicle(x=-20.0, y=3.5),   # rear: 20 m behind, stationary → TTC = inf
+        ]
+        scene = make_scene(objects=objs, ego_speed=3.0)
+        result = gs.assess(scene, left_target())
+        assert result.safe
+        assert result.front_gap_m >= 12.0
+        assert result.rear_gap_m >= 10.0
+
+    def test_unavailable_target_lane_is_unsafe(self):
+        gs = GapSelector()
+        unavail = TargetLaneCandidate(
+            available=False, direction="none", lane_id="",
+            confidence=0.0, lateral_offset_m=0.0, reason="no lane",
+        )
+        result = gs.assess(make_scene(), unavail)
+        assert not result.safe
+
+    def test_no_ego_pose_is_unsafe(self):
+        gs = GapSelector()
+        scene = make_scene()
+        scene.ego_pose = None
+        result = gs.assess(scene, left_target())
+        assert not result.safe
+
+    def test_objects_in_current_lane_dont_fail_gap(self):
+        gs = GapSelector(min_rear_gap_m=10.0)
+        # Object is in current lane (y=0), not target lane (y=3.5)
+        scene = make_scene(objects=[vehicle(x=-5.0, y=0.0)])
+        result = gs.assess(scene, left_target())
+        # rear gap check should not trigger for current-lane objects
+        assert result.rear_gap_m > 10.0

--- a/src/planning/navigator_lane_change/test/test_need_detector.py
+++ b/src/planning/navigator_lane_change/test/test_need_detector.py
@@ -1,0 +1,108 @@
+"""Unit tests for NeedDetector — no ROS required."""
+
+import time
+import pytest
+from navigator_lane_change.need_detector import NeedDetector
+from navigator_lane_change.types import (
+    Scene, EgoPose, TrackedObject, TopicHealth,
+)
+
+
+def make_scene(objects=None, path=None, intersection_stop=False, ego_speed=0.0):
+    if path is None:
+        # Straight path along +X axis from origin
+        path = [(float(i), 0.0, 0.0) for i in range(0, 100, 2)]
+    return Scene(
+        stamp=time.time(),
+        ego_pose=EgoPose(x=0.0, y=0.0, z=0.0, yaw=0.0),
+        ego_speed=ego_speed,
+        ego_heading=0.0,
+        current_path=path,
+        nearby_objects=objects or [],
+        intersection_stop=intersection_stop,
+        topic_health=TopicHealth(
+            odom_fresh=True, path_fresh=True,
+            objects_fresh=True, intersection_fresh=True
+        ),
+    )
+
+
+def stopped_vehicle(x, y=0.0, speed=0.0):
+    return TrackedObject(
+        object_id="sv1", classification="vehicle",
+        x=x, y=y, z=0.0,
+        vx=speed, vy=0.0,
+        length=4.5, width=2.0, height=1.5,
+    )
+
+
+class TestNeedDetector:
+    def test_no_objects_returns_no_need(self):
+        nd = NeedDetector(min_blockage_duration_s=0.0)
+        scene = make_scene(objects=[])
+        result = nd.detect(scene)
+        assert not result.needed
+        assert result.reason == "path_clear"
+
+    def test_stopped_vehicle_ahead_triggers_need(self):
+        nd = NeedDetector(min_blockage_duration_s=0.0)
+        scene = make_scene(objects=[stopped_vehicle(x=15.0)])
+        result = nd.detect(scene)
+        assert result.needed
+        assert result.reason == "stopped_object_blocking_path"
+        assert result.blockage_distance_m < 20.0
+
+    def test_moving_vehicle_does_not_trigger(self):
+        nd = NeedDetector(min_blockage_duration_s=0.0)
+        # Vehicle moving at 5 m/s — above stopped threshold of 0.5
+        scene = make_scene(objects=[stopped_vehicle(x=15.0, speed=5.0)])
+        result = nd.detect(scene)
+        assert not result.needed
+
+    def test_vehicle_behind_ego_does_not_trigger(self):
+        nd = NeedDetector(min_blockage_duration_s=0.0)
+        scene = make_scene(objects=[stopped_vehicle(x=-10.0)])
+        result = nd.detect(scene)
+        assert not result.needed
+
+    def test_vehicle_outside_corridor_does_not_trigger(self):
+        nd = NeedDetector(
+            min_blockage_duration_s=0.0, path_corridor_half_width_m=1.8
+        )
+        # Vehicle is 5 m to the left — well outside 1.8 m corridor
+        scene = make_scene(objects=[stopped_vehicle(x=15.0, y=5.0)])
+        result = nd.detect(scene)
+        assert not result.needed
+
+    def test_intersection_stop_suppresses_need(self):
+        nd = NeedDetector(min_blockage_duration_s=0.0)
+        scene = make_scene(
+            objects=[stopped_vehicle(x=15.0)],
+            intersection_stop=True,
+        )
+        result = nd.detect(scene)
+        assert not result.needed
+        assert result.reason == "intersection_stop_active"
+
+    def test_blockage_must_persist_before_trigger(self):
+        nd = NeedDetector(min_blockage_duration_s=2.0)
+        scene = make_scene(objects=[stopped_vehicle(x=15.0)])
+        # First call — not long enough
+        result = nd.detect(scene)
+        assert not result.needed
+        assert result.reason == "blockage_too_brief"
+
+    def test_no_odometry_returns_no_need(self):
+        nd = NeedDetector()
+        scene = make_scene()
+        scene.ego_pose = None
+        result = nd.detect(scene)
+        assert not result.needed
+        assert result.reason == "no_odometry"
+
+    def test_no_path_returns_no_need(self):
+        nd = NeedDetector()
+        scene = make_scene(path=[])
+        result = nd.detect(scene)
+        assert not result.needed
+        assert result.reason == "no_path"

--- a/src/planning/navigator_lane_change/test/test_safety_checker.py
+++ b/src/planning/navigator_lane_change/test/test_safety_checker.py
@@ -1,0 +1,87 @@
+"""Unit tests for SafetyChecker — no ROS required."""
+
+import time
+from navigator_lane_change.safety_checker import SafetyChecker
+from navigator_lane_change.types import (
+    Scene, EgoPose, TopicHealth, GapAssessment,
+)
+
+
+def safe_gap():
+    return GapAssessment(
+        safe=True, front_gap_m=25.0, rear_gap_m=18.0,
+        rear_ttc_s=6.0, side_overlap=False, reason="gap_accepted",
+    )
+
+
+def unsafe_gap(reason="rear_ttc_2.0s<4.0s"):
+    return GapAssessment(
+        safe=False, front_gap_m=25.0, rear_gap_m=18.0,
+        rear_ttc_s=2.0, side_overlap=False, reason=reason,
+    )
+
+
+def make_scene(
+    odom_fresh=True, path_fresh=True, ego_speed=3.0, intersection_stop=False
+):
+    path = [(float(i), 0.0, 0.0) for i in range(0, 50, 2)]
+    return Scene(
+        stamp=time.time(),
+        ego_pose=EgoPose(x=0.0, y=0.0, z=0.0, yaw=0.0),
+        ego_speed=ego_speed,
+        ego_heading=0.0,
+        current_path=path,
+        nearby_objects=[],
+        intersection_stop=intersection_stop,
+        topic_health=TopicHealth(
+            odom_fresh=odom_fresh, path_fresh=path_fresh,
+            objects_fresh=True, intersection_fresh=True,
+        ),
+    )
+
+
+class TestSafetyChecker:
+    def test_all_ok_returns_safe(self):
+        sc = SafetyChecker()
+        result = sc.check(make_scene(), safe_gap())
+        assert result.safe
+        assert result.blockers == []
+
+    def test_stale_odom_blocks(self):
+        sc = SafetyChecker()
+        result = sc.check(make_scene(odom_fresh=False), safe_gap())
+        assert not result.safe
+        assert "odom_stale" in result.blockers
+
+    def test_stale_path_blocks(self):
+        sc = SafetyChecker()
+        result = sc.check(make_scene(path_fresh=False), safe_gap())
+        assert not result.safe
+        assert "path_stale" in result.blockers
+
+    def test_high_speed_blocks(self):
+        sc = SafetyChecker(max_lane_change_speed_mps=5.0)
+        result = sc.check(make_scene(ego_speed=9.0), safe_gap())
+        assert not result.safe
+        assert any("above_max" in b for b in result.blockers)
+
+    def test_intersection_stop_blocks(self):
+        sc = SafetyChecker()
+        result = sc.check(make_scene(intersection_stop=True), safe_gap())
+        assert not result.safe
+        assert "intersection_stop_active" in result.blockers
+
+    def test_unsafe_gap_blocks(self):
+        sc = SafetyChecker()
+        result = sc.check(make_scene(), unsafe_gap())
+        assert not result.safe
+        assert any("gap_unsafe" in b for b in result.blockers)
+
+    def test_multiple_blockers_all_reported(self):
+        sc = SafetyChecker(max_lane_change_speed_mps=5.0)
+        result = sc.check(
+            make_scene(odom_fresh=False, ego_speed=9.0, intersection_stop=True),
+            unsafe_gap(),
+        )
+        assert not result.safe
+        assert len(result.blockers) >= 3

--- a/src/planning/navigator_lane_change/test/test_state_machine.py
+++ b/src/planning/navigator_lane_change/test/test_state_machine.py
@@ -1,0 +1,177 @@
+"""Unit tests for LaneChangeStateMachine — no ROS required."""
+
+import time
+import pytest
+from navigator_lane_change.lane_change_state_machine import (
+    LaneChangeStateMachine, LCState,
+)
+from navigator_lane_change.types import (
+    Scene, EgoPose, TopicHealth,
+    LaneChangeNeed, TargetLaneCandidate, GapAssessment, SafetyResult,
+)
+
+
+# ------------------------------------------------------------------ helpers
+
+def make_scene(odom_fresh=True, path_fresh=True):
+    return Scene(
+        stamp=time.time(),
+        ego_pose=EgoPose(0.0, 0.0, 0.0, 0.0),
+        ego_speed=3.0, ego_heading=0.0,
+        current_path=[(float(i), 0.0, 0.0) for i in range(0, 50, 2)],
+        nearby_objects=[],
+        intersection_stop=False,
+        topic_health=TopicHealth(
+            odom_fresh=odom_fresh, path_fresh=path_fresh,
+            objects_fresh=True, intersection_fresh=True,
+        ),
+    )
+
+
+def no_need():
+    return LaneChangeNeed(
+        needed=False, reason="path_clear", urgency="none",
+        blockage_distance_m=float("inf"), suggested_direction="none",
+    )
+
+
+def need():
+    return LaneChangeNeed(
+        needed=True, reason="stopped_object_blocking_path", urgency="normal",
+        blockage_distance_m=15.0, suggested_direction="left",
+    )
+
+
+def target_ok():
+    return TargetLaneCandidate(
+        available=True, direction="left", lane_id="adjacent_left",
+        confidence=0.88, lateral_offset_m=3.5, reason="clear",
+    )
+
+
+def target_unavail():
+    return TargetLaneCandidate(
+        available=False, direction="none", lane_id="",
+        confidence=0.0, lateral_offset_m=0.0, reason="no_lane",
+    )
+
+
+def gap_safe():
+    return GapAssessment(
+        safe=True, front_gap_m=25.0, rear_gap_m=18.0,
+        rear_ttc_s=6.5, side_overlap=False, reason="gap_accepted",
+    )
+
+
+def gap_unsafe():
+    return GapAssessment(
+        safe=False, front_gap_m=25.0, rear_gap_m=5.0,
+        rear_ttc_s=1.5, side_overlap=False, reason="rear_gap too small",
+    )
+
+
+def safety_ok():
+    return SafetyResult(safe=True, blockers=[])
+
+
+def safety_gap_fail():
+    return SafetyResult(safe=False, blockers=["gap_unsafe:rear_ttc_1.5s<4.0s"])
+
+
+def safety_hard_fail():
+    return SafetyResult(safe=False, blockers=["odom_stale"])
+
+
+# ------------------------------------------------------------------ tests
+
+class TestStateMachine:
+    def test_initial_state_is_idle(self):
+        sm = LaneChangeStateMachine()
+        assert sm.state == LCState.IDLE
+
+    def test_idle_to_prepare_when_need_detected(self):
+        sm = LaneChangeStateMachine()
+        sm.update(make_scene(), need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.PREPARE_LANE_CHANGE
+
+    def test_idle_stays_idle_when_no_need(self):
+        sm = LaneChangeStateMachine()
+        sm.update(make_scene(), no_need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.IDLE
+
+    def test_full_happy_path_idle_to_execute(self):
+        sm = LaneChangeStateMachine()
+        scene = make_scene()
+        # IDLE → PREPARE
+        sm.update(scene, need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.PREPARE_LANE_CHANGE
+        # PREPARE → CHECK_TARGET_LANE
+        sm.update(scene, need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.CHECK_TARGET_LANE
+        # CHECK → FIND_GAP
+        sm.update(scene, need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.FIND_GAP
+        # FIND_GAP → COMMIT
+        sm.update(scene, need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.COMMIT_LANE_CHANGE
+        # COMMIT → EXECUTE
+        sm.update(scene, need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.EXECUTE_LANE_CHANGE
+
+    def test_stale_inputs_cause_fault(self):
+        sm = LaneChangeStateMachine()
+        sm.update(make_scene(odom_fresh=False), need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.FAULT
+
+    def test_fault_recovers_to_idle_when_inputs_return(self):
+        sm = LaneChangeStateMachine()
+        sm.update(make_scene(odom_fresh=False), need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.FAULT
+        sm.update(make_scene(odom_fresh=True), no_need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.IDLE
+
+    def test_no_target_lane_goes_to_route_blocked(self):
+        sm = LaneChangeStateMachine()
+        scene = make_scene()
+        sm.update(scene, need(), target_unavail(), gap_unsafe(), safety_gap_fail())
+        # IDLE → PREPARE
+        assert sm.state == LCState.PREPARE_LANE_CHANGE
+        sm.update(scene, need(), target_unavail(), gap_unsafe(), safety_gap_fail())
+        # PREPARE → ROUTE_BLOCKED (no target)
+        assert sm.state == LCState.ROUTE_BLOCKED
+
+    def test_safety_hard_failure_during_prepare_goes_to_fault(self):
+        sm = LaneChangeStateMachine()
+        scene = make_scene()
+        sm.update(scene, need(), target_ok(), gap_safe(), safety_ok())
+        # Now hard failure (odom stale) appears
+        sm.update(make_scene(odom_fresh=False), need(), target_ok(), gap_safe(), safety_hard_fail())
+        assert sm.state == LCState.FAULT
+
+    def test_safety_failure_during_execute_aborts(self):
+        sm = LaneChangeStateMachine()
+        scene = make_scene()
+        # Fast-forward to EXECUTE
+        for _ in range(5):
+            sm.update(scene, need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.EXECUTE_LANE_CHANGE
+        # Safety failure during execution
+        sm.update(scene, need(), target_ok(), gap_unsafe(), safety_gap_fail())
+        assert sm.state == LCState.ABORT_LANE_CHANGE
+
+    def test_mark_complete_transitions_to_complete(self):
+        sm = LaneChangeStateMachine()
+        scene = make_scene()
+        for _ in range(5):
+            sm.update(scene, need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.EXECUTE_LANE_CHANGE
+        sm.mark_complete()
+        assert sm.state == LCState.COMPLETE_LANE_CHANGE
+
+    def test_need_cleared_during_prepare_returns_to_idle(self):
+        sm = LaneChangeStateMachine()
+        scene = make_scene()
+        sm.update(scene, need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.PREPARE_LANE_CHANGE
+        sm.update(scene, no_need(), target_ok(), gap_safe(), safety_ok())
+        assert sm.state == LCState.IDLE


### PR DESCRIPTION
## Summary

- Adds the `navigator_lane_change` ROS 2 package — a **shadow-mode** behavior node that decides when and how to change lanes, publishing decisions with zero vehicle control authority
- Introduces external lane-change command support (`/behavior/lane_change_command`) so operators and the route planner can request left/right lane changes directly
- Adds merging-conflict detection in the gap selector to block a lane change when a vehicle in the target lane is simultaneously moving laterally toward ego, reducing collision risk from simultaneous merges

## Architecture

```
/gnss/odometry  ──┐
/planning/path  ──┤  SceneBuilder ──► NeedDetector ──► TargetLaneSelector
/objdet3d_tracked─┤                                          │
/intersection_status                                    GapSelector ◄── merging conflict check
/lane_change_command ─► (commanded direction in Scene)       │
                                                       SafetyChecker
                                                             │
                                                    LaneChangeStateMachine (11 states)
                                                             │
                    /behavior/lane_change_state    (String)
                    /behavior/lane_change_decision (JSON)
                    /behavior/lane_change_debug    (JSON)
```

## New topics

| Topic | Direction | Type | Notes |
|---|---|---|---|
| `/behavior/lane_change_command` | SUB | `std_msgs/String` | `"left"`, `"right"`, or `"cancel"` |
| `/behavior/lane_change_state` | PUB | `std_msgs/String` | Current FSM state name |
| `/behavior/lane_change_decision` | PUB | `std_msgs/String` | JSON decision summary |
| `/behavior/lane_change_debug` | PUB | `std_msgs/String` | JSON full debug dump |

## Key design decisions

- **FAULT only on odometry loss** — path missing handled gracefully; node stays IDLE when path planner is offline
- **Commands expire after 30 s** — stale commands cannot drive an unsafe lane change if operator connection drops
- **Merging conflict threshold** — configurable via `merging_conflict_lat_speed_mps` (default 0.4 m/s)
- **Shadow mode** — `shadow_mode: true` in params; no path to vehicle actuation in this PR

## Test results

12/12 pure-Python simulation tests pass (no ROS or CARLA required):

| Test | Result |
|---|---|
| FAULT → IDLE on odom restore | PASS |
| Clear road stays IDLE | PASS |
| Stopped obstacle → PREPARE_LANE_CHANGE | PASS |
| Full FSM flow → EXECUTE_LANE_CHANGE | PASS |
| High speed blocks commit | PASS |
| mark_complete() → IDLE | PASS |
| Intersection stop suppresses lane change | PASS |
| Command 'left' triggers lane change | PASS |
| Command 'right' triggers lane change | PASS |
| Cancel command aborts lane change | PASS |
| Merging vehicle blocks gap acceptance | PASS |
| Non-merging vehicle → proceeds to EXECUTE | PASS |

## Not in this PR

- PR 2: Quintic polynomial path generator for the lane-change trajectory
- PR 3: Execution integration — connecting FSM EXECUTE state to vehicle control
