### PR TITLE
fix(costs): correct grid output size and origin for all costmap nodes

### DIFF
--- a/src/planning/costs/costs/grid_summation_node.py
+++ b/src/planning/costs/costs/grid_summation_node.py
@@ -294,8 +294,15 @@ class GridSummationNode(Node):
                 elif len(grid.data) > data_dim:
                     grid.data = grid.data[:data_dim]
 
+                # Only sensor grids (occupancy) need fast-forwarding when stale.
+                # Map-based grids (drivable, route_dist, junction, lane_control) are
+                # already computed for the current vehicle pose — fast-forwarding them
+                # applies TF noise + ndimage transforms on every cycle, causing visible
+                # jitter in RViz (especially since drivable publishes at ~0.7 Hz and is
+                # therefore always "stale" by the 0.25 s threshold).
+                SENSOR_GRIDS = ('occupancy', 'future_occupancy')
                 stale = self.checkForStaleness(grid)
-                if stale > 0:
+                if stale > 0 and grid_name in SENSOR_GRIDS:
                     ff_grid = self.fastforward(grid)
                     weighted_grid_arr = self.getWeightedArrayFromOccupancyGrid(ff_grid, scale)
                 else:
@@ -303,8 +310,7 @@ class GridSummationNode(Node):
                     # np.asarray(arr, ...) converts values — safe for masked arrays and
                     # plain ndarrays alike.  Do NOT use arr.data which is a raw byte
                     # buffer and reinterprets memory, causing a reshape ValueError when
-                    # the source dtype is wider than float16 (e.g. float64 from
-                    # resizeOccupancyGrid's np.zeros output).
+                    # the source dtype is wider than float16.
                     # NOTE: occupancy grids now publish at 300×300 (from StaticOccupancyNode
                     # fix); resizeOccupancyGrid expected 128×128 input and will crash with
                     # 300×300 — do not call it here.

--- a/src/planning/costs/costs/grid_summation_node.py
+++ b/src/planning/costs/costs/grid_summation_node.py
@@ -300,14 +300,14 @@ class GridSummationNode(Node):
                     weighted_grid_arr = self.getWeightedArrayFromOccupancyGrid(ff_grid, scale)
                 else:
                     ff_grid = occupancygrid_to_numpy(grid)
-                    # Occupancy sensors publish at 128×128; resize to 151×151 once here.
-                    if grid_name in ('occupancy', 'future_occupancy'):
-                        ff_grid = self.resizeOccupancyGrid(ff_grid)
                     # np.asarray(arr, ...) converts values — safe for masked arrays and
                     # plain ndarrays alike.  Do NOT use arr.data which is a raw byte
                     # buffer and reinterprets memory, causing a reshape ValueError when
                     # the source dtype is wider than float16 (e.g. float64 from
                     # resizeOccupancyGrid's np.zeros output).
+                    # NOTE: occupancy grids now publish at 300×300 (from StaticOccupancyNode
+                    # fix); resizeOccupancyGrid expected 128×128 input and will crash with
+                    # 300×300 — do not call it here.
                     weighted_grid_arr = np.asarray(ff_grid, dtype=np.float16) * scale
 
                 # Normalise every layer to 151×151 before accumulation.
@@ -343,68 +343,39 @@ class GridSummationNode(Node):
                 print(f"Error parsing YAML file: {e}")
 
             # Publish steering cost — resized to config dimensions via cv2
+            resolution = data['occupancy_grids']['resolution']
+            grid_cols = int(data['occupancy_grids']['width']  / resolution)  # 300
+            grid_rows = int(data['occupancy_grids']['length'] / resolution)  # 300
+
             steering_cost_msg = OccupancyGrid()
             steering_cost_msg.info.map_load_time = self.clock.clock
-            steering_cost_msg.info.resolution = data['occupancy_grids']['resolution']
-            steering_cost_msg.info.origin.position.x = -1 * data['occupancy_grids']['vehicle_latitudinal_location']
-            steering_cost_msg.info.origin.position.y = -1 * data['occupancy_grids']['vehicle_longitudinal_location']
+            steering_cost_msg.info.resolution = resolution
+            # origin is the lower-left corner of the map in base_link:
+            # x = forward (longitudinal), y = left (latitudinal)
+            steering_cost_msg.info.origin.position.x = -1 * data['occupancy_grids']['vehicle_longitudinal_location']
+            steering_cost_msg.info.origin.position.y = -1 * data['occupancy_grids']['vehicle_latitudinal_location']
             steering_cost_msg.header.stamp = self.clock.clock
             steering_cost_msg.header.frame_id = 'base_link'
 
-            resized_grid = cv2.resize(steering_cost, (60, 60), interpolation=cv2.INTER_NEAREST)
+            resized_grid = cv2.resize(steering_cost.astype(np.float32), (grid_cols, grid_rows), interpolation=cv2.INTER_NEAREST)
             steering_cost_msg.data = resized_grid.astype(np.int8).flatten().tolist()
-            steering_cost_msg.info.width  = int(data['occupancy_grids']['width'])
-            steering_cost_msg.info.height = int(data['occupancy_grids']['length'])
+            steering_cost_msg.info.width  = grid_cols
+            steering_cost_msg.info.height = grid_rows
 
             self.steering_cost_pub.publish(steering_cost_msg)
 
             speed_cost_msg = OccupancyGrid()
             speed_cost_msg.info.map_load_time = self.clock.clock
-            speed_cost_msg.info.resolution = data['occupancy_grids']['resolution']
-            speed_cost_msg.info.width  = speed_cost.shape[1]  # cols = x (width)
-            speed_cost_msg.info.height = speed_cost.shape[0]  # rows = y (height)
-            speed_cost_msg.info.origin.position.x = -1 * data['occupancy_grids']['vehicle_latitudinal_location']
-            speed_cost_msg.info.origin.position.y = -1 * data['occupancy_grids']['vehicle_longitudinal_location']
+            speed_cost_msg.info.resolution = resolution
+            speed_cost_msg.info.origin.position.x = -1 * data['occupancy_grids']['vehicle_longitudinal_location']
+            speed_cost_msg.info.origin.position.y = -1 * data['occupancy_grids']['vehicle_latitudinal_location']
             speed_cost_msg.header.stamp = self.clock.clock
             speed_cost_msg.header.frame_id = 'base_link'
-            speed_cost_msg.data = speed_cost.astype(np.int8).flatten().tolist()
 
-            # Resize speed cost grid to match size specified in config file
-            if speed_cost_msg.info.height != data['occupancy_grids']['length']:
-                diff = (data['occupancy_grids']['length'] - speed_cost_msg.info.height) / speed_cost_msg.info.resolution
-                diff = int(diff)
-
-                if diff < 0:
-                    speed_cost_msg.data = speed_cost_msg.data[:int(diff * speed_cost_msg.info.width)]
-                elif diff > 0:
-                    speed_cost_msg.data.extend([-1] * int(diff * speed_cost_msg.info.width))
-
-                speed_cost_msg.info.height = int(data['occupancy_grids']['length'])
-
-            if speed_cost_msg.info.width != data['occupancy_grids']['width']:
-                diff = (data['occupancy_grids']['width'] - speed_cost_msg.info.width) / speed_cost_msg.info.resolution
-                diff = int(diff)
-
-                if diff < 0:
-                    new_grid = [-1] * int(data['occupancy_grids']['width'] * speed_cost_msg.info.height)
-                    offset = int(diff / 2 * -1)
-
-                    for i in range(int(speed_cost_msg.info.height)):
-                        start = int(i * data['occupancy_grids']['width'] + offset)
-                        end = int(((i + 1) * data['occupancy_grids']['width']) - 1 - offset)
-                        new_grid[int(i * data['occupancy_grids']['width']):int((i + 1) * data['occupancy_grids']['width'] - 1)] = speed_cost_msg.data[start:end]
-
-                    speed_cost_msg.data = new_grid
-                elif diff > 0:
-                    new_grid = [-1] * int(data['occupancy_grids']['width'] * speed_cost_msg.info.height)
-                    offset = int(diff / 2)
-                    for i in range(int(speed_cost_msg.info.height)):
-                        start = int(i * data['occupancy_grids']['width'] + offset)
-                        end = int(((i + 1) * data['occupancy_grids']['width']) - 1 - offset)
-                        new_grid[start:end] = speed_cost_msg.data[int(i * speed_cost_msg.info.width):int((i + 1) * speed_cost_msg.info.width)]
-                    speed_cost_msg.data = new_grid
-
-                speed_cost_msg.info.width = int(data['occupancy_grids']['width'])
+            resized_speed = cv2.resize(speed_cost.astype(np.float32), (grid_cols, grid_rows), interpolation=cv2.INTER_NEAREST)
+            speed_cost_msg.data = resized_speed.astype(np.int8).flatten().tolist()
+            speed_cost_msg.info.width  = grid_cols
+            speed_cost_msg.info.height = grid_rows
 
             self.speed_cost_pub.publish(speed_cost_msg)
         except (Exception) as e:

--- a/src/planning/costs/costs/grid_summation_node.py
+++ b/src/planning/costs/costs/grid_summation_node.py
@@ -63,6 +63,13 @@ class GridSummationNode(Node):
         self.declare_parameter('global_config', 'temp_value')
         self.file_path = self.get_parameter('global_config').value
 
+        # Cache fastforward results keyed by (grid_name, stamp_secs) so we
+        # don't re-run TF lookup + ndimage.rotate/shift/zoom for the same
+        # grid on every 20 Hz timer tick — repeated calls with the same stale
+        # grid produce slightly different rotations due to TF floating-point
+        # noise, which causes visible shimmering in RViz.
+        self._ff_cache = {}  # {grid_name: (stamp_secs, weighted_arr)}
+
         # Subscriptions and publishers
         self.tf_buffer = Buffer()
         self.tf_listener = TransformListener(self.tf_buffer, self)
@@ -301,10 +308,19 @@ class GridSummationNode(Node):
                 # jitter in RViz (especially since drivable publishes at ~0.7 Hz and is
                 # therefore always "stale" by the 0.25 s threshold).
                 SENSOR_GRIDS = ('occupancy', 'future_occupancy')
+                stamp_secs = grid.header.stamp.sec + grid.header.stamp.nanosec * 1e-9
                 stale = self.checkForStaleness(grid)
                 if stale > 0 and grid_name in SENSOR_GRIDS:
-                    ff_grid = self.fastforward(grid)
-                    weighted_grid_arr = self.getWeightedArrayFromOccupancyGrid(ff_grid, scale)
+                    # Use cached fastforward result if the grid stamp hasn't changed.
+                    # Without this, the same stale grid is re-rotated/shifted on every
+                    # 20 Hz tick with slightly different TF values, producing shimmer.
+                    cached = self._ff_cache.get(grid_name)
+                    if cached is not None and abs(cached[0] - stamp_secs) < 1e-6:
+                        weighted_grid_arr = cached[1]
+                    else:
+                        ff_grid = self.fastforward(grid)
+                        weighted_grid_arr = self.getWeightedArrayFromOccupancyGrid(ff_grid, scale)
+                        self._ff_cache[grid_name] = (stamp_secs, weighted_grid_arr)
                 else:
                     ff_grid = occupancygrid_to_numpy(grid)
                     # np.asarray(arr, ...) converts values — safe for masked arrays and

--- a/src/planning/costs/costs/route_costmap_node.py
+++ b/src/planning/costs/costs/route_costmap_node.py
@@ -34,6 +34,7 @@ from tf_transformations import quaternion_multiply, euler_from_quaternion
 from ros2_numpy.occupancy_grid import occupancygrid_to_numpy, numpy_to_occupancy_grid
 # to do image rotations/shifts for fast forwarding occupancy grids
 from scipy import ndimage
+import cv2
 
 from visualization_msgs.msg import Marker
 from std_msgs.msg import ColorRGBA
@@ -285,51 +286,29 @@ class RouteCostmapNode(Node):
         except yaml.YAMLError as e:
             print(f"Error parsing YAML file: {e}")
 
-        # Publish as an OccupancyGrid
+        # Publish as an OccupancyGrid, resized to config dimensions via cv2
+        resolution = data['occupancy_grids']['resolution']
+        grid_cols = int(data['occupancy_grids']['width']  / resolution)  # 300
+        grid_rows = int(data['occupancy_grids']['length'] / resolution)  # 300
+
         route_cost_msg = OccupancyGrid()
         route_cost_msg.info.map_load_time = self.clock.clock
-        route_cost_msg.info.resolution = data['occupancy_grids']['resolution']
-        route_cost_msg.info.width = int(data['occupancy_grids']['width'])
-        route_cost_msg.info.height = int(data['occupancy_grids']['length'])
-        route_cost_msg.info.origin.position.x = -1 * data['occupancy_grids']['vehicle_latitudinal_location']
-        route_cost_msg.info.origin.position.y = -1 * data['occupancy_grids']['vehicle_longitudinal_location']
+        route_cost_msg.info.resolution = resolution
+        route_cost_msg.info.width  = grid_cols
+        route_cost_msg.info.height = grid_rows
+        # origin is the lower-left corner of the map in base_link:
+        # x = forward (longitudinal), y = left (latitudinal)
+        route_cost_msg.info.origin.position.x = -1 * data['occupancy_grids']['vehicle_longitudinal_location']
+        route_cost_msg.info.origin.position.y = -1 * data['occupancy_grids']['vehicle_latitudinal_location']
         route_cost_msg.header.stamp = self.clock.clock
         route_cost_msg.header.frame_id = 'base_link'
-        route_cost_msg.data = routemap.astype(np.int8).flatten().tolist()
 
-        # Resize occupancy grid to match size specified in config file
-        if routemap.shape[0] != route_cost_msg.info.height:
-            diff = (route_cost_msg.info.height - routemap.shape[0]) / route_cost_msg.info.resolution
-            diff = int(diff)  # Convert to integer
-            
-            if diff < 0:
-                route_cost_msg.data = route_cost_msg.data[:int(diff * routemap.shape[1])]
-            elif diff > 0:
-                route_cost_msg.data.extend([-1] * int(diff * routemap.shape[1]))
-        
-        if routemap.shape[1] != route_cost_msg.info.width:
-            diff = (route_cost_msg.info.width - routemap.shape[1]) / route_cost_msg.info.resolution     
-            diff = int(diff)  # Convert to integer
-        
-            if diff < 0:
-                new_grid = [-1] * int(data['occupancy_grids']['width'] * route_cost_msg.info.height)
-                offset = int(diff / 2 * -1)
-                
-                for i in range(int(route_cost_msg.info.height)):
-                    start = int(i * data['occupancy_grids']['width'] + offset)
-                    end = int(((i + 1) * data['occupancy_grids']['width']) - 1 - offset)
-
-                    new_grid[int(i * data['occupancy_grids']['width']):int((i + 1) * data['occupancy_grids']['width'] - 1)] = route_cost_msg.data[start:end]
-
-                route_cost_msg.data = new_grid
-            elif diff > 0:
-                new_grid = [-1] * int(route_cost_msg.info.width * route_cost_msg.info.height)
-                offset = int(diff / 2)
-                for i in range(int(route_cost_msg.info.height)):
-                    start = int(i * route_cost_msg.info.width + offset)
-                    end = int(((i + 1) * route_cost_msg.info.width) - 1 - offset)
-                    new_grid[start:end] = route_cost_msg.data[int(i * routemap.shape[1]):int((i + 1) * routemap.shape[1])]
-                route_cost_msg.data = new_grid
+        resized_routemap = cv2.resize(
+            routemap.astype(np.float32),
+            (grid_cols, grid_rows),
+            interpolation=cv2.INTER_NEAREST
+        )
+        route_cost_msg.data = np.clip(resized_routemap, -128, 127).astype(np.int8).flatten().tolist()
 
         self.route_dist_grid_pub.publish(route_cost_msg)
 


### PR DESCRIPTION
## Summary

- **`grid_summation_node`**: Remove `resizeOccupancyGrid` calls for `occupancy`/`future_occupancy` grids. `StaticOccupancyNode` now publishes at 300×300; the old 128→151 resize logic crashes with an `IndexError` (`background[22:22+250]` exceeds a 151-row array) when given 300×300 input. Replace the broken `cv2.resize(cost, (60, 60))` (which treated 60m as 60 cells = 12m×12m) with a resolution-aware resize to 300×300 cells for both `steering_cost` and `speed_cost`. Fix origin x/y swap: `x = -vehicle_longitudinal_location`, `y = -vehicle_latitudinal_location`. Replace broken diff-padding speed cost resize with `cv2.resize`.
- **`route_costmap_node`**: Add `import cv2`. Replace broken diff-padding resize (treated meters as cells, producing 60×60 grids with all -1 data) with `cv2.resize` to the correct 300×300 cell count derived from `width / resolution`. Fix origin x/y swap consistent with other nodes.


Tested in RVIZ to ensure validity

<img width="434" height="502" alt="Screenshot 2026-05-21 at 7 06 48 PM" src="https://github.com/user-attachments/assets/5497a52c-99ab-46a1-815d-88f3341c1427" />
Occupancy Grid

<img width="795" height="624" alt="Screenshot 2026-05-21 at 7 06 40 PM" src="https://github.com/user-attachments/assets/c004585d-43c1-47fb-92dd-a470aa55ceb2" />
Steering Cost

<img width="791" height="613" alt="Screenshot 2026-05-21 at 7 06 29 PM" src="https://github.com/user-attachments/assets/f69a3d71-144d-437a-8249-635fdc66c8b2" />
Steering Cost, Occupancy Grid, and Drivable Area ]
