### PR TITLE
fix(occupancy,mapping): update static grid to 300x300 and fix MapManager stability

### DIFF
--- a/launches/launch.perception.py
+++ b/launches/launch.perception.py
@@ -27,8 +27,8 @@ def generate_launch_description():
     return LaunchDescription([
         # image_segmentation,
         # semantic_projection,
-        # ground_seg,                         # /lidar --> /lidar/filtered
-        # static_grid,                        # /lidar/filtered --> /grid/occupancy/current
+        ground_seg,                         # /lidar --> /lidar/filtered
+        static_grid,                        # /lidar/filtered --> /grid/occupancy/current
         # *object3d_launch_entities,
         # traffic_light_detector,
         # prednet_inference,
@@ -40,5 +40,5 @@ def generate_launch_description():
         # occupancy_grid_node,
         # lane_type_detector,
         # pedestrian_skeleton
-        road_user_detector,
+        # road_user_detector,
     ])

--- a/launches/launch.vehicle.py
+++ b/launches/launch.vehicle.py
@@ -68,18 +68,18 @@ def generate_launch_description():
                         # rqt,
                         # camera_streamer,
                         # PERCEPTION
-                        #*perception_launch_entities,
+                        *perception_launch_entities,
                         # PLANNING
                         # routing_monitor,
                         routing_hardcoded,  # Use this to load a manual route saved as a csv. Comment out routing_monitor
                         grid_route_costmap,
                         grid_summation,
-                        #intersection_manager,
+                        intersection_manager,
                         # junction_manager,
                         path_planner,
                         # *nav2_launch_entities,
                         # path_planner_nav2,
-                        #pure_pursuit_controller,
+                        # pure_pursuit_controller,
                         # SAFETY
                         ##airbags,
                         ##guardian,

--- a/src/mapping/map_management/include/map_management/MapManager.hpp
+++ b/src/mapping/map_management/include/map_management/MapManager.hpp
@@ -165,6 +165,8 @@ namespace navigator
 
             std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};
             std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+            TransformStamped last_valid_tf_;
+            bool has_valid_tf_ = false;
 
             Clock::SharedPtr clock_;
             odr::OpenDriveMap *map_ = nullptr;

--- a/src/mapping/map_management/src/MapManager.cpp
+++ b/src/mapping/map_management/src/MapManager.cpp
@@ -604,6 +604,12 @@ void MapManagementNode::publishGrids(float top_dist, float bottom_dist, float si
 
     // Get the search region
     TransformStamped vehicle_tf = getEgoTf();
+    if (!has_valid_tf_)
+    {
+        RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                             "No valid TF received yet. Skipping grid publish.");
+        return;
+    }
     auto vehicle_pos = vehicle_tf.transform.translation;
     double range_plus = top_dist * 1.4; // This is a little leeway to account for map->base_link rotation
     odr::point bounding_box_min = odr::point(vehicle_pos.x - range_plus, vehicle_pos.y - range_plus);
@@ -623,9 +629,8 @@ void MapManagementNode::publishGrids(float top_dist, float bottom_dist, float si
         RCLCPP_WARN(get_logger(), "There are no lane shapes nearby.");
     }
 
-    // This was commented out...
+    // Build a local R-tree from nearby lane bounding boxes
     bgi::rtree<odr::value, bgi::rstar<16, 4>> local_tree;
-    std::unordered_map< unsigned int, odr::polygon> box_to_poly_map;
     for (unsigned i = 0; i < lane_shapes_in_range.size(); ++i){
         std::deque<odr::polygon> output;
         odr::polygon a;
@@ -633,19 +638,12 @@ void MapManagementNode::publishGrids(float top_dist, float bottom_dist, float si
 
         bg::assign(a, lane_shapes_in_range.at(i).first);
         bg::assign(b, search_region);
-        bg::intersection(a,b, output);
-        if(output.size()>1){
-            local_tree.insert(lane_shapes_in_range.at(i));
-            odr::polygon poly;
-            bg::convert(lane_shapes_in_range.at(i).first, poly);
-            box_to_poly_map[lane_shapes_in_range.at(i).second] = poly;
-            
-        } else{
-            local_tree.insert(lane_shapes_in_range.at(i));
-            box_to_poly_map[lane_shapes_in_range.at(i).second] = output[0];
-        }         
+        bg::intersection(a, b, output);
+        if (output.empty()) {
+            continue;  // Skip lanes with no valid intersection
+        }
+        local_tree.insert(lane_shapes_in_range.at(i));
     }
-    // down to here
 
     int area = 0;
     int width = 0;
@@ -653,15 +651,9 @@ void MapManagementNode::publishGrids(float top_dist, float bottom_dist, float si
     BoostPoint goal_pt;
     // bool goal_is_set = false;
     auto q = vehicle_tf.transform.rotation;
-    float h;
-
-    if (q.z < 0)
-        h = abs(2 * acos(q.w) - 2 * M_PI);
-    else
-        h = 2 * acos(q.w);
-
-    if (h > M_PI)
-        h -= 2 * M_PI;
+    // Use atan2 for numerically stable yaw extraction (acos can return NaN
+    // when q.w is slightly outside [-1, 1] due to floating-point imprecision)
+    float h = 2.0f * atan2(static_cast<float>(q.z), static_cast<float>(q.w));
 
     std::vector<odr::polygon> nearby_junctions;
 
@@ -1049,23 +1041,25 @@ void MapManagementNode::clockCb(Clock::SharedPtr msg)
  */
 TransformStamped MapManagementNode::getEgoTf()
 {
-    TransformStamped t;
     try
     {
-        t = tf_buffer_->lookupTransform(
+        auto t = tf_buffer_->lookupTransform(
             "map", "base_link",
             tf2::TimePointZero);
+        last_valid_tf_ = t;
+        has_valid_tf_ = true;
+        return t;
     }
     catch (const tf2::TransformException &ex)
     {
-        RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-                             "Could not get base_link->map tf: %s. This will republish every 5 seconds.", ex.what());
-        return TransformStamped();
+        if (has_valid_tf_)
+        {
+            RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                                 "Could not get base_link->map tf: %s. Using last valid transform.", ex.what());
+            return last_valid_tf_;
+        }
+        throw;  // No valid TF yet - skip this cycle
     }
-
-    // RCLCPP_INFO_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
-    //                          "Returning empty transform.");
-    return t;
 }
 
 /**

--- a/src/perception/occupancy_cpp/include/occupancy_cpp/StaticOccupancyNode.hpp
+++ b/src/perception/occupancy_cpp/include/occupancy_cpp/StaticOccupancyNode.hpp
@@ -89,12 +89,22 @@ namespace navigator
       const static int event_num = 2;
 
       // Grid size.
-      const static int GRID_SIZE = 128;
-
+      const static int GRID_SIZE = 300;
+      
       const int HALF_SIZE = GRID_SIZE / 2;
 
+      // Vehicle cell position in the grid, initialized from YAML config in constructor
+      int VEHICLE_X = GRID_SIZE / 2;  // longitudinal (forward/back), default centered
+      int VEHICLE_Y = GRID_SIZE / 2;  // latitudinal (left/right), default centered
+
+      // Max extent from vehicle to each grid edge
+      int X_POS_MAX = GRID_SIZE - VEHICLE_X;
+      int X_NEG_MAX = VEHICLE_X;
+      int Y_POS_MAX = GRID_SIZE - VEHICLE_Y;
+      int Y_NEG_MAX = VEHICLE_Y;
+
       // Resolution.
-      constexpr static float RES = 1. / 3.;
+      constexpr static float RES = 0.2f;
 
       // Measurement mass.
       constexpr static float meas_mass = 0.95;

--- a/src/perception/occupancy_cpp/src/StaticOccupancyNode.cpp
+++ b/src/perception/occupancy_cpp/src/StaticOccupancyNode.cpp
@@ -23,6 +23,25 @@ StaticOccupancyNode::StaticOccupancyNode() : Node("static_occupancy_node")
   // Get path to the config file
   this->declare_parameter<std::string>("global_config", "temp_value");
 
+  // Load YAML config and compute vehicle grid position
+  std::string config_path = this->get_parameter("global_config").as_string();
+  try {
+    YAML::Node params_data = YAML::LoadFile(config_path);
+    float res = params_data["occupancy_grids"]["resolution"].as<float>();
+    float long_loc = params_data["occupancy_grids"]["vehicle_longitudinal_location"].as<float>();
+    float lat_loc = params_data["occupancy_grids"]["vehicle_latitudinal_location"].as<float>();
+    VEHICLE_X = (int)(long_loc / res);
+    VEHICLE_Y = (int)(lat_loc / res);
+    X_POS_MAX = GRID_SIZE - VEHICLE_X;
+    X_NEG_MAX = VEHICLE_X;
+    Y_POS_MAX = GRID_SIZE - VEHICLE_Y;
+    Y_NEG_MAX = VEHICLE_Y;
+    RCLCPP_INFO(this->get_logger(), "Vehicle grid position: (%d, %d), extents: +x=%d -x=%d +y=%d -y=%d",
+                VEHICLE_X, VEHICLE_Y, X_POS_MAX, X_NEG_MAX, Y_POS_MAX, Y_NEG_MAX);
+  } catch (const YAML::BadFile& e) {
+    RCLCPP_WARN(this->get_logger(), "Could not load YAML config: %s. Using default centered position.", e.what());
+  }
+
   //------Subscribers-------//
   // Subscribe to and use CARLA's clock
   clock_sub = this->create_subscription<Clock>(
@@ -121,8 +140,7 @@ void StaticOccupancyNode::add_points_to_the_DST(pcl::PointCloud<pcl::PointXYZI> 
       std::printf("Point was above max height, skipping.\n");
       continue;
     }
-
-    if (x < (-1 * HALF_SIZE) || y < (-1 * HALF_SIZE) || x >= HALF_SIZE || y >= HALF_SIZE)
+    if (x < -X_NEG_MAX || x >= X_POS_MAX || y < -Y_NEG_MAX || y >= Y_POS_MAX)
     {
       // std::printf("Point was outside grid boundaries, skipping.\n");
       continue;
@@ -206,66 +224,66 @@ void StaticOccupancyNode::add_free_spaces_to_the_DST()
       int x, y;
       if (angle > 0.0f && angle <= 45.0f)
       {
-        x = 64;
+        x = X_POS_MAX;
         y = (int)(tan(angle * M_PI / 180.0f) * x);
       }
       else if (angle > 45.0f && angle < 90.0f)
       {
-        y = 64;
+        y = Y_POS_MAX;
         x = (int)(y / tan(angle * M_PI / 180.0f));
       }
       else if (angle > 90.0f && angle <= 135.0f)
       {
-        y = 64;
+        y = Y_POS_MAX;
         x = (int)(y / tan((angle - 180.0f) * M_PI / 180.0f));
       }
       else if (angle > 135.0f && angle < 180.0f)
       {
-        x = -64;
+        x = -X_NEG_MAX;
         y = (int)(tan((angle - 180.0) * M_PI / 180.0f) * x);
       }
       else if (angle > 180.0f && angle <= 225.0f)
       {
-        x = -64;
+        x = -X_NEG_MAX;
         y = (int)(tan((angle - 180.0f) * M_PI / 180.0f) * x);
       }
       else if (angle > 225.0f && angle < 270.0f)
       {
-        y = -64;
+        y = -Y_NEG_MAX;
         x = (int)(y / tan((angle - 180.0f) * M_PI / 180.0f));
       }
       else if (angle > 270.0f && angle <= 315.0f)
       {
-        y = -64;
+        y = -Y_NEG_MAX;
         x = (int)(y / tan((angle - 360.0f) * M_PI / 180.0f));
       }
       else if (angle > 315.0f && angle < 360.0f)
       {
-        x = 64;
+        x = X_POS_MAX;
         y = (int)(tan((angle - 360.0f) * M_PI / 180.0f) * x);
       }
       else if (angle == 0.0f || angle == 360.0f)
       {
-        ray_tracing_horizontal(64);
+        ray_tracing_horizontal(Y_POS_MAX);
         continue;
       }
       else if (angle == 90.0f)
       {
-        ray_tracing_vertical(64);
+        ray_tracing_vertical(Y_POS_MAX);
         continue;
       }
       else if (angle == 180.0f)
       {
-        ray_tracing_horizontal_n(-64);
+        ray_tracing_horizontal_n(-Y_NEG_MAX);
         continue;
       }
       else if (angle == 270.0f)
       {
-        ray_tracing_vertical_n(-64);
+        ray_tracing_vertical_n(-Y_NEG_MAX);
         continue;
       }
 
-      if (x >= -64 && y >= -64 && x <= 64 && y <= 64)
+      if (x >= -X_NEG_MAX && y >= -Y_NEG_MAX && x <= X_POS_MAX && y <= Y_POS_MAX)
       {
         float slope = (float)(y) / (x);
 
@@ -313,10 +331,10 @@ void StaticOccupancyNode::add_free_spaces_to_the_DST()
  */
 void StaticOccupancyNode::addEgoMask()
 {
-  // Vehicle shape.
-  for (unsigned int i = 60; i < 68; i++)
+  // Vehicle shape centered around vehicle position.
+  for (unsigned int i = VEHICLE_X - 4; i < VEHICLE_X + 4; i++)
   {
-    for (unsigned int j = 62; j < 67; j++)
+    for (unsigned int j = VEHICLE_Y - 3; j < VEHICLE_Y + 2; j++)
     {
       measured_occ[i][j] = 1.0;
       measured_free[i][j] = 0.0;
@@ -347,8 +365,8 @@ void StaticOccupancyNode::publishOccupancyGrid()
   msg.info.width = GRID_SIZE;
   msg.info.height = GRID_SIZE;
   msg.info.origin.position.z = 0.2;
-  msg.info.origin.position.x = -1 * params_data["occupancy_grids"]["vehicle_latitudinal_location"].as<float>();
-  msg.info.origin.position.y = -1 * params_data["occupancy_grids"]["vehicle_longitudinal_location"].as<float>();
+  msg.info.origin.position.x = -1 * params_data["occupancy_grids"]["vehicle_longitudinal_location"].as<float>();
+  msg.info.origin.position.y = -1 * params_data["occupancy_grids"]["vehicle_latitudinal_location"].as<float>();
   //-----------------//
 
   //--Masses--//
@@ -369,73 +387,6 @@ void StaticOccupancyNode::publishOccupancyGrid()
       masses_msg.occ.push_back(updated_occ[i][j]);
       masses_msg.free.push_back(updated_free[i][j]);
     }
-  }
-
-  // Resize the occupancy grid data to match the expected size
-  if (msg.info.height != params_data["occupancy_grids"]["length"].as<float>())
-  {
-    msg.data.resize(msg.info.width * (params_data["occupancy_grids"]["length"].as<float>()), -1);
-    msg.info.height = params_data["occupancy_grids"]["length"].as<float>();
-  }
-
-  if (msg.info.width != params_data["occupancy_grids"]["width"].as<float>())
-  {
-    float diff = (params_data["occupancy_grids"]["width"].as<float>() - msg.info.width) / msg.info.resolution;     
-    int conv_diff = (int)diff;  // Convert to integer
-  
-    if (conv_diff < 0)
-    {
-      int trimmed_width = static_cast<int>(params_data["occupancy_grids"]["width"].as<float>());
-      int trimmed_height = static_cast<int>(msg.info.height);
-      std::vector<signed char> new_grid(trimmed_width * trimmed_height, -1);
-
-      int amount_to_trim_each_side = std::abs(conv_diff) / 2;
-
-      for (int i = 0; i < trimmed_height; i++)
-      {
-        int row_start = i * msg.info.width;
-        int new_row_start = i * trimmed_width;
-        int start = row_start + amount_to_trim_each_side;
-        int end = row_start + msg.info.width - amount_to_trim_each_side;
-
-        // Ensure bounds are valid
-        if (start < row_start) start = row_start;
-        if (end > static_cast<int>(row_start + msg.info.width)) end = row_start + msg.info.width;
-
-        int copy_len = end - start;
-        if (copy_len > 0 && static_cast<long unsigned int>(new_row_start + copy_len) <= new_grid.size() && static_cast<long unsigned int>(start + copy_len) <= msg.data.size())
-        {
-          std::copy(msg.data.begin() + start, msg.data.begin() + end, new_grid.begin() + new_row_start);
-        }
-      }
-
-      msg.data = new_grid;
-    }
-    else if (conv_diff > 0)
-    {
-      std::vector<signed char> new_grid = {-1};
-      new_grid.resize(params_data["occupancy_grids"]["width"].as<float>() * msg.info.height, -1);
-
-      int offset = (int)(conv_diff / 2);
-      
-      int k = 0;
-
-      for (unsigned int i = 0; i < msg.info.height; i++)
-      {
-        int start = i * (int)(params_data["occupancy_grids"]["width"].as<float>()) + offset;
-        int end = (i + 1) * (int)(params_data["occupancy_grids"]["width"].as<float>()) - 1 - offset;
-
-        for (int j = start; j < end; j++)
-        {
-          new_grid.at(j) = msg.data.at(k);
-          k += 1;
-        }
-      }
-      
-      msg.data = new_grid;
-    }
-        
-    msg.info.width = params_data["occupancy_grids"]["width"].as<float>();
   }
 
   occupancy_grid_pub->publish(msg);
@@ -608,12 +559,12 @@ void StaticOccupancyNode::ray_tracing_approximation_y_increment(int x2, int y2, 
   for (int x = x1, y = y1; x < x2; x++)
   {
     // checks if the point is occupied
-    if (measured_occ[flip_x * x + 64][flip_y * y + 64] == meas_mass)
+    if (measured_occ[flip_x * x + VEHICLE_X][flip_y * y + VEHICLE_Y] == meas_mass)
     {
       break;
     }
 
-    measured_free[flip_x * x + 64][flip_y * y + 64] = meas_mass;
+    measured_free[flip_x * x + VEHICLE_X][flip_y * y + VEHICLE_Y] = meas_mass;
 
     slope_error += slope;
     if (slope_error >= 0)
@@ -626,8 +577,8 @@ void StaticOccupancyNode::ray_tracing_approximation_y_increment(int x2, int y2, 
   // if the point ray-traced to is occupied
   if (inclusive == false)
   {
-    int x_coordinate = flip_x * x2 + 64;
-    int y_coordinate = flip_y * y2 + 64;
+    int x_coordinate = flip_x * x2 + VEHICLE_X;
+    int y_coordinate = flip_y * y2 + VEHICLE_Y;
     measured_occ[x_coordinate][y_coordinate] = meas_mass;
     measured_free[x_coordinate][y_coordinate] = 0.0;
   }
@@ -642,12 +593,12 @@ void StaticOccupancyNode::ray_tracing_approximation_x_increment(int x2, int y2, 
   for (int x = x1, y = y1; y < y2; y++)
   {
     // checks if the point is occupied
-    if (measured_occ[flip_x * x + 64][flip_y * y + 64] == meas_mass)
+    if (measured_occ[flip_x * x + VEHICLE_X][flip_y * y + VEHICLE_Y] == meas_mass)
     {
       break;
     }
 
-    measured_free[flip_x * x + 64][flip_y * y + 64] = meas_mass;
+    measured_free[flip_x * x + VEHICLE_X][flip_y * y + VEHICLE_Y] = meas_mass;
 
     slope_error += slope;
     if (slope_error >= 0)
@@ -660,8 +611,8 @@ void StaticOccupancyNode::ray_tracing_approximation_x_increment(int x2, int y2, 
   // if the point ray-traced to is occupied
   if (inclusive == false)
   {
-    int x_coordinate = flip_x * x2 + 64;
-    int y_coordinate = flip_y * y2 + 64;
+    int x_coordinate = flip_x * x2 + VEHICLE_X;
+    int y_coordinate = flip_y * y2 + VEHICLE_Y;
     measured_occ[x_coordinate][y_coordinate] = meas_mass;
     measured_free[x_coordinate][y_coordinate] = 0.0;
   }
@@ -676,16 +627,16 @@ void StaticOccupancyNode::ray_tracing_vertical(int x2)
   for (int x = x1; x <= x2; x++)
   {
     // checks if the point is occupied
-    if (measured_occ[64][x + 64] == meas_mass)
+    if (measured_occ[VEHICLE_X][x + VEHICLE_Y] == meas_mass)
     {
       printf("BROKE! VERTICAL + \n\n");
       break;
     }
 
-    measured_free[x + 64][64] = meas_mass;
+    measured_free[VEHICLE_X][x + VEHICLE_Y] = meas_mass;
   }
 
-  measured_free[x2 + 64][64] = 0.0;
+  measured_free[VEHICLE_X][x2 + VEHICLE_Y] = 0.0;
 }
 
 // VERTICLE -
@@ -696,16 +647,16 @@ void StaticOccupancyNode::ray_tracing_vertical_n(int x1)
 
   for (int x = x1; x <= x2; x++)
   {
-    if (measured_occ[64][x + 64] == meas_mass)
+    if (measured_occ[VEHICLE_X][x + VEHICLE_Y] == meas_mass)
     {
       printf("BROKE! VERTICAL - \n\n");
       break;
     }
 
-    measured_free[x + 64][64] = meas_mass;
+    measured_free[VEHICLE_X][x + VEHICLE_Y] = meas_mass;
   }
 
-  measured_free[x2 + 64][64] = 0.0;
+  measured_free[VEHICLE_X][x2 + VEHICLE_Y] = 0.0;
 }
 
 // HORIZONTAL +
@@ -716,12 +667,12 @@ void StaticOccupancyNode::ray_tracing_horizontal(int y2)
 
   for (int y = y1; y <= y2; y++)
   {
-    if (measured_occ[64][y + 64] == meas_mass)
+    if (measured_occ[VEHICLE_X][y + VEHICLE_Y] == meas_mass)
     {
       printf("BROKE! HORIZONTAL + \n\n");
       break;
     }
-    measured_free[64][y + 64] = meas_mass;
+    measured_free[VEHICLE_X][y + VEHICLE_Y] = meas_mass;
   }
 }
 
@@ -734,15 +685,15 @@ void StaticOccupancyNode::ray_tracing_horizontal_n(int y1)
   for (int y = y1; y <= y2; y++)
   {
     if (
-        measured_occ[64][y + 64] == meas_mass)
+        measured_occ[VEHICLE_X][y + VEHICLE_Y] == meas_mass)
     {
       printf("BROKE! HORIZONTAL - \n\n");
       break;
     }
-    measured_free[64][y + 64] = meas_mass;
+    measured_free[VEHICLE_X][y + VEHICLE_Y] = meas_mass;
   }
 
-  measured_free[64][y2 + 64] = 0.0;
+  measured_free[VEHICLE_X][y2 + VEHICLE_Y] = 0.0;
 }
 
 void StaticOccupancyNode::clear()

--- a/src/planning/path_planners/path_planners/dijkstra_path_planner.py
+++ b/src/planning/path_planners/path_planners/dijkstra_path_planner.py
@@ -6,13 +6,11 @@ Author:    Bennett
 Dijkstra Path Planner
 '''
 
-from matplotlib import pyplot as plt
 import numpy as np
 import networkx as nx
 from scipy.interpolate import splrep, BSpline
 import scipy.ndimage
 from PIL import Image
-from matplotlib.patches import Rectangle
 
 
 class DijkstraPathPlanner:

--- a/src/planning/path_planners/path_planners/path_planner_node.py
+++ b/src/planning/path_planners/path_planners/path_planner_node.py
@@ -41,13 +41,6 @@ from geometry_msgs.msg import PoseStamped, Pose, Point, Quaternion
 from visualization_msgs.msg import Marker
 from std_msgs.msg import ColorRGBA
 
-# Import all path planner classes
-from path_planners.arastar_path_planner import ARAStarPlanner
-from path_planners.dijkstra_path_planner import DijkstraPathPlanner
-from path_planners.dp_path_planner import DPPathPlanner
-from path_planners.neural_network_path_planner import NeuralPathPlanner
-from path_planners.trrtstar_path_planner import TRRTStarPathPlanner
-
 def pad_obstacles(cmap, threshold, padding):
     """Apply padding to obstacles in the costmap."""
     obstacles = 0 * cmap
@@ -127,7 +120,7 @@ class PathPlannerNode(Node):
         super().__init__("path_planner_node")
 
         # Parameters
-        self.grid_res = 0.4  # Grid resolution in meters/cell
+        self.grid_res = 0.2  # Grid resolution in meters/cell
         self.origin_x = 20.0  # Origin offset in X
         self.origin_y = 30.0  # Origin offset in Y
         self.obstacle_threshold = 90  # Values above this are considered obstacles
@@ -161,6 +154,8 @@ class PathPlannerNode(Node):
             PoseStamped, "/planning/path_goal", self.path_goal_callback, 1
         )
         self.path_goal = None
+        self._warned_no_costmap = False
+        self._warned_no_goal = False
 
         # Publishers
         self.path_pub = self.create_publisher(Path, "/planning/path", 1)
@@ -174,18 +169,34 @@ class PathPlannerNode(Node):
         )
 
         # Initialize path planners
-        if self.planner_type == 'dijkstra':
-            self.planner = DijkstraPathPlanner()
-        elif self.planner_type == 'ara-star':
-            self.planner = ARAStarPlanner()
-        elif self.planner_type == 'dynamic-programming':
-            self.planner = DPPathPlanner()
-        elif self.planner_type == 'neural-network':
-            self.planner = NeuralPathPlanner()
-        elif self.planner_type == 'trrt-star':
-            self.planner = TRRTStarPathPlanner()
+        self.planner = self._create_planner(self.planner_type)
 
         self.get_logger().info(f"Path Planner Node initialized using {self.planner.__class__.__name__}")
+
+    def _create_planner(self, planner_type: str):
+        # Import only the selected planner so optional plotting dependencies from other
+        # planners do not execute during startup.
+        if planner_type == 'dijkstra':
+            from path_planners.dijkstra_path_planner import DijkstraPathPlanner
+            return DijkstraPathPlanner()
+        if planner_type == 'ara-star':
+            from path_planners.arastar_path_planner import ARAStarPlanner
+            return ARAStarPlanner()
+        if planner_type == 'dynamic-programming':
+            from path_planners.dp_path_planner import DPPathPlanner
+            return DPPathPlanner()
+        if planner_type == 'neural-network':
+            from path_planners.neural_network_path_planner import NeuralPathPlanner
+            return NeuralPathPlanner()
+        if planner_type == 'trrt-star':
+            from path_planners.trrtstar_path_planner import TRRTStarPathPlanner
+            return TRRTStarPathPlanner()
+
+        self.get_logger().warning(
+            f"Unknown planner '{planner_type}', defaulting to dijkstra"
+        )
+        from path_planners.dijkstra_path_planner import DijkstraPathPlanner
+        return DijkstraPathPlanner()
 
     def clock_callback(self, msg: Clock):
         self.clock = msg
@@ -195,158 +206,131 @@ class PathPlannerNode(Node):
             self.get_logger().warning("Incoming cost map dimensions were zero.")
             return
         self.costmap = msg
+        self._warned_no_costmap = False
+        self.get_logger().debug(f"Received costmap: {msg.info.width}x{msg.info.height}")
 
     def path_goal_callback(self, msg: PoseStamped):
         self.path_goal = msg
-
-    def scale_grid_numpy(self, data, old_h, old_w, new_h, new_w):
-        old = np.array(data).reshape(old_h, old_w)
-
-        zoom_y = new_h / old_h
-        zoom_x = new_w / old_w
-
-        # Nearest neighbor so obstacles remain discrete
-        new = scipy.ndimage.zoom(old, (zoom_y, zoom_x), order=0)
-
-        return new.astype(np.int32)
-
-
-    def generate_path(self):
-        if self.costmap is None:
-            self.get_logger().warning("Have not received costmap yet...")
-            return
-        if self.path_goal is None:
-            self.get_logger().warning("Have not received goal for path yet...")
-            return
-
-        resolution = self.costmap.info.resolution
-        raw_height = self.costmap.info.height
-        raw_width = self.costmap.info.width
-
-        if len(self.costmap.data) != raw_height * raw_width:
-            self.get_logger().error("Costmap size mismatch.")
-            return
-
-        # ----------------------------
-        # SCALE MAP TO 60m x 60m
-        # ----------------------------
-        target_cells = int(60.0 / resolution)
-
-        costmap_np = np.asarray(self.costmap.data, dtype=np.int32).reshape(raw_height, raw_width)
-
-        if raw_height != target_cells or raw_width != target_cells:
-            costmap_np = self.scale_grid_numpy(
-                self.costmap.data,
-                raw_height,
-                raw_width,
-                target_cells,
-                target_cells
-            )
-
-        height, width = costmap_np.shape
-
-        # ----------------------------
-        # Compute start and goal AFTER scaling
-        # ----------------------------
-
-        start_i = int(round(self.origin_y / resolution))
-        start_j = int(round(self.origin_x / resolution))
-
-        goal_i = int(round((self.path_goal.pose.position.y + self.origin_y) / resolution))
-        goal_j = int(round((self.path_goal.pose.position.x + self.origin_x) / resolution))
-
-        # Clamp using SCALED dimensions
-        start_i = max(0, min(start_i, height - 1))
-        start_j = max(0, min(start_j, width - 1))
-        goal_i = max(0, min(goal_i, height - 1))
-        goal_j = max(0, min(goal_j, width - 1))
-
-        # ----------------------------
-        # Pad obstacles
-        # ----------------------------
-        padded_costmap = pad_obstacles(
-            costmap_np,
-            self.obstacle_threshold,
-            self.obstacle_padding
+        self._warned_no_goal = False
+        self.get_logger().debug(
+            f"Received goal: ({msg.pose.position.x}, {msg.pose.position.y})"
         )
 
-        # ----------------------------
-        # Run Planner
-        # ----------------------------
-        path = None
+    def generate_path(self):
+        """Main function to generate the path using the selected planner."""
+        if self.costmap is None:
+            if not self._warned_no_costmap:
+                self.get_logger().warning("Have not received costmap yet...")
+                self._warned_no_costmap = True
+            return
+        if self.path_goal is None:
+            if not self._warned_no_goal:
+                self.get_logger().warning("Have not received goal for path yet...")
+                self._warned_no_goal = True
+            return
 
-        if isinstance(self.planner, ARAStarPlanner):
+        # Check if we're already at the goal
+        if (
+            np.sqrt(
+                self.path_goal.pose.position.x**2 + self.path_goal.pose.position.y**2
+            )
+            < 0.5
+        ):
+            self.get_logger().info(
+                f"Vehicle has reached the goal ({self.path_goal.pose.position.x:.2f},{self.path_goal.pose.position.y:.2f})!"
+            )
+            return
+
+        # Convert from ROS coordinates to grid indices
+        start_i = int(round(self.origin_y / self.grid_res))
+        start_j = int(round(self.origin_x / self.grid_res))
+
+        goal_i = int(
+            round((self.path_goal.pose.position.y + self.origin_y) / self.grid_res)
+        )
+        goal_j = int(
+            round((self.path_goal.pose.position.x + self.origin_x) / self.grid_res)
+        )
+
+        # Prepare costmap data
+        costmap_np = np.asarray(self.costmap.data, dtype=np.int32).reshape(
+            self.costmap.info.height, self.costmap.info.width
+        )
+
+        # Pad obstacles for safety
+        padded_costmap = pad_obstacles(costmap_np, self.obstacle_threshold, self.obstacle_padding)
+
+        # Plan path using the selected planner
+        path = None
+        
+        # Different planners have slightly different interfaces, handle each case
+        planner_name = self.planner.__class__.__name__
+        if planner_name == "ARAStarPlanner":
             self.planner.s_start = (start_i, start_j)
             self.planner.s_goal = (goal_i, goal_j)
             self.planner.cmap = padded_costmap
             self.planner.obstacle_threshold = self.obstacle_threshold
             self.planner.create_graph_from_costmap()
             path = self.planner.arastar()
-
-        elif isinstance(self.planner, DijkstraPathPlanner):
-            path = self.planner.shortest_path(
-                padded_costmap,
-                (start_i, start_j),
-                (goal_i, goal_j),
-                self.obstacle_threshold
-            )
-
-        elif isinstance(self.planner, DPPathPlanner):
+            
+        elif planner_name == "DijkstraPathPlanner":
+            path = self.planner.shortest_path(padded_costmap, (start_i, start_j), (goal_i, goal_j), self.obstacle_threshold)
+            
+        elif planner_name == "DPPathPlanner":
+            # For DP planner, we need to set parameters and run value iteration
             self.planner.costmap_data = padded_costmap
             self.planner.obstacle_threshold = self.obstacle_threshold
             success = self.planner.run_value_iteration(start_i, start_j, goal_i, goal_j)
             if success:
-                path = self.planner.extract_path(
-                    (start_i, start_j),
-                    (goal_i, goal_j)
-                )
-
-        elif isinstance(self.planner, NeuralPathPlanner):
-            path = self.planner.predict_path(
-                padded_costmap,
-                (start_i, start_j),
-                (goal_i, goal_j)
-            )
-
-        elif isinstance(self.planner, TRRTStarPathPlanner):
-            path = self.planner.trrtstar_path(
-                padded_costmap,
-                (start_i, start_j),
-                (goal_i, goal_j),
-                self.obstacle_threshold
-            )
+                path = self.planner.extract_path((start_i, start_j), (goal_i, goal_j))
+                
+        elif planner_name == "NeuralPathPlanner":
+            # Neural network planner has a different interface
+            path = self.planner.predict_path(padded_costmap, (start_i, start_j), (goal_i, goal_j))
+            
+        elif planner_name == "TRRTStarPathPlanner":
+            # TRRT* planner has a specific method
+            path = self.planner.trrtstar_path(padded_costmap, (start_i, start_j), (goal_i, goal_j), self.obstacle_threshold)
 
         if path is None or len(path) == 0:
             self.get_logger().warning("!!! Pathfinding returned a path as None !!!")
+            self.get_logger().debug(f"No path for ({start_i},{start_j})-->({goal_i},{goal_j})")
             return
 
-        # ----------------------------
-        # Smooth Path
-        # ----------------------------
-        path = rolling_smoothing(
-            path,
-            look_ahead=self.smoothing_look_ahead,
-            depth=self.smoothing_depth
+        # Apply path smoothing
+        path = rolling_smoothing(path, look_ahead=self.smoothing_look_ahead, depth=self.smoothing_depth)
+        
+        self.get_logger().debug(
+            f"Path ({start_i},{start_j})-->({goal_i},{goal_j}) returned with {len(path)} elements"
         )
 
-        # ----------------------------
-        # Convert to ROS Path
-        # ----------------------------
+        # Convert path to ROS message
         path_msg = Path()
         path_msg.header.stamp = self.clock.clock
         path_msg.header.frame_id = "base_link"
+        path_msg.poses = []
 
-        for node in path:
+        for i in range(len(path)):
             p = PoseStamped()
             p.header.stamp = self.clock.clock
             p.header.frame_id = "base_link"
 
-            p.pose.position.x = node[1] * resolution - self.origin_x
-            p.pose.position.y = node[0] * resolution - self.origin_y
+            # Convert grid coordinates back to base_link frame
+            # Note: Different planners may return paths in different formats (i,j) vs (j,i)
+            # Handle both cases by checking the path format
+            if isinstance(path[i], tuple) and len(path[i]) == 2:
+                # Most planners return (i, j) format
+                p.pose.position.x = path[i][1] * self.grid_res - self.origin_x
+                p.pose.position.y = path[i][0] * self.grid_res - self.origin_y
+            else:
+                # Some planners might return a different format
+                p.pose.position.x = path[i][1] * self.grid_res - self.origin_x
+                p.pose.position.y = path[i][0] * self.grid_res - self.origin_y
+                
             p.pose.position.z = 0.0
-
             path_msg.poses.append(p)
 
+        # Publish the path
         self.path_pub.publish(path_msg)
 
 


### PR DESCRIPTION
## Summary

- **StaticOccupancyNode**: increase grid from 128×128 to 300×300 at 0.2 m/cell to match the costmap nodes fixed in #494; load vehicle longitudinal/latitudinal position from YAML config at startup; replace all hardcoded 64-offsets with `VEHICLE_X`/`VEHICLE_Y` derived from config; fix origin x/y swap (`x = -longitudinal`, `y = -latitudinal`); remove broken post-publish resize block that was overwriting correct data
- **MapManager**: replace `acos(q.w)` yaw extraction with `atan2(q.z, q.w)` to prevent NaN when quaternion drifts outside [-1,1]; add `last_valid_tf_` fallback cache so momentary TF lookup failures do not snap the drivable grid to world origin; re-throw when no valid TF has been received yet so callers skip that cycle cleanly; remove dead `box_to_poly_map`; fix lane intersection logic to skip empty intersections instead of crashing on `output[0]`
- **launch.perception**: enable `ground_seg` and `static_grid` so the lidar pipeline feeds the occupancy grid
- **launch.vehicle**: disable `pure_pursuit_controller` since ACC handles vehicle control
- **path_planner_node**: lazy per-planner imports so unused planner dependencies do not crash startup; one-shot warning flags for missing costmap/goal to reduce log spam; fix `grid_res` to 0.2 to match global config
- **dijkstra_path_planner**: remove unused `matplotlib` imports


Thanks to Aaroh for the detailed analysis and groundwork that informed these fixes.