### PR TITLE
fix(perception): publish bbox width/height, not full-image dims

### DIFF
--- a/src/perception/pedestrian_intent_to_enter_road/pedestrian_intent_to_enter_road/pedestrian_intent_to_enter_road.py
+++ b/src/perception/pedestrian_intent_to_enter_road/pedestrian_intent_to_enter_road/pedestrian_intent_to_enter_road.py
@@ -95,8 +95,8 @@ class PedestrianIntentToEnterRoad(Node):
                     else:
                         continue
 
-                    height, width, channels = self.image.shape
-                    midpoint_x = width / 2
+                    img_h, img_w = self.image.shape[:2]
+                    midpoint_x = img_w / 2
 
                     if (((direction_facing == self.FACING_RIGHT) and (center_x < midpoint_x)) or ((direction_facing == self.FACING_LEFT) and (center_x > midpoint_x))):
                         # for pedestrians facing the road, determine the distance between them and the road


### PR DESCRIPTION
Inside `detect_pedestrians()`, the image-shape unpack `height, width, channels = self.image.shape` clobbered the YOLO bbox `width`/`height`, so every `PedestrianInfo` carried the full image dimensions instead of the bbox dimensions. Renamed those locals to `img_h`/`img_w` so they no longer shadow the bbox dims.

`PedestrianInfo` has no consumers yet, so this changes no live behavior.