### PR TITLE
Add pretrained YOLOPv2 front-camera lane segmentation

### DIFF
--- a/launches/launch.perception.py
+++ b/launches/launch.perception.py
@@ -41,10 +41,11 @@ def generate_launch_description():
         # lane_type_detector,
         # pedestrian_skeleton
         # road_user_detector,      # YOLO model required - disabled until model present
-        # image_segmentation,      # mmseg/PSPNet required - disabled until installed
+        image_segmentation,        # mmseg/PSPNet, now installed -- runs on cuda:1
         ground_seg,
         static_grid,
         hybrid_grid,
         perception_drivable_grid,
         hybrid_drivable_grid,
+        yolopv2_lane,
     ])

--- a/launches/launch_node_definitions.py
+++ b/launches/launch_node_definitions.py
@@ -280,6 +280,13 @@ perception_drivable_grid = Node(
     output="screen",
 )
 
+yolopv2_lane = Node(
+    package="segmentation",
+    executable="yolopv2_lane_node",
+    name="yolopv2_lane_node",
+    output="screen",
+)
+
 hybrid_drivable_grid = Node(
     package="segmentation",
     executable="hybrid_drivable_grid_node",

--- a/src/perception/lane_type_detector/lane_type_detector/lane_type_detector.py
+++ b/src/perception/lane_type_detector/lane_type_detector/lane_type_detector.py
@@ -2,6 +2,15 @@
 Package: lane_type_detector
 File: lane_type_detector.py
 Author: Pranav Boyapati
+
+Bug fix (image encoding crash + hardcoded frame-width assumption):
+Siddarth Nandyala <siddarth.nandyala@utdallas.edu>
+- image_callback previously requested cv_bridge encoding '8UC3', which is
+  not a valid conversion target for this camera's actual bgra8 encoding
+  and raised a CvBridgeError on every single frame -- changed to 'bgr8'.
+- numLanesLeftOfImageCenter compared box centers against a hardcoded
+  image width of 400, which does not match this camera's real resolution
+  -- changed to read the actual image width at runtime.
 """
 
 import rclpy
@@ -43,7 +52,10 @@ class LaneTypeDetector(Node):
 
     #callbacks for subscriptions
     def image_callback(self, msg : Image):
-        self.image = self.bridge.imgmsg_to_cv2(msg, desired_encoding='8UC3')
+        # /cameras/camera0 publishes bgra8; '8UC3' isn't a real encoding
+        # conversion target for cv_bridge (it errored on every frame) --
+        # bgr8 is the standard 3-channel format YOLO expects.
+        self.image = self.bridge.imgmsg_to_cv2(msg, desired_encoding='bgr8')
         self.make_lane_detections()
 
     
@@ -74,7 +86,8 @@ class LaneTypeDetector(Node):
                 numTotalLanes += 1
                 
                 x1, y1, x2, y2 = box
-                if (((x1 + x2) / 2) < (400 / 2)):
+                image_width = self.image.shape[1]  # was hardcoded to 400, wrong for this camera's actual resolution
+                if (((x1 + x2) / 2) < (image_width / 2)):
                     numLanesLeftOfImageCenter += 1
                 
             if (int(cls) == 1):

--- a/src/perception/segmentation/segmentation/bev_geometry.py
+++ b/src/perception/segmentation/segmentation/bev_geometry.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+bev_geometry.py — shared camera-to-BEV projection geometry.
+
+Author: Siddarth Nandyala
+Email: siddarth.nandyala@utdallas.edu
+
+Extracted from perception_drivable_grid_node.py so every grid-publishing node
+(drivable grid, lane grid, ...) stays pixel-aligned on the same 300x300
+@0.2m/cell base_link grid and the same hardcoded camera extrinsics, instead of
+each node re-deriving its own projection.
+
+Cameras (hardcoded from carla_objects.json — camera TF frames do not exist):
+  K: fx=fy=571.12, cx=400, cy=300  (fov=70, 800x600)
+  R_cb(theta) = [[sin t, 0, cos t], [-cos t, 0, sin t], [0, -1, 0]]
+  front: t=(0.7,-0.15,1.88) yaw=0    /semantic/front
+  right: t=(0.7,-0.15,1.88) yaw=-70  /semantic/right
+  left:  t=(0.7, 0.15,1.88) yaw=+70  /semantic/left
+  back:  t=(-1.5,0.0, 1.88) yaw=180  /semantic/back (needs rgb_back in carla_objects.json)
+"""
+
+import math
+
+import numpy as np
+
+GRID_SIZE     = 300
+RESOLUTION    = 0.2
+ORIGIN_X      = -20.0
+ORIGIN_Y      = -30.0
+MAX_PROJ_DIST = 40.0
+
+VEHICLE_COL = int((0.0 - ORIGIN_X) / RESOLUTION)   # 100
+VEHICLE_ROW = int((0.0 - ORIGIN_Y) / RESOLUTION)   # 150
+
+FX = FY = 571.12
+CX, CY = 400.0, 300.0
+IMG_W, IMG_H = 800, 600
+
+K = np.array([[FX, 0.0, CX], [0.0, FY, CY], [0.0, 0.0, 1.0]], dtype=np.float64)
+K_INV = np.linalg.inv(K)
+
+
+def R_cb(yaw_deg):
+    t = math.radians(yaw_deg)
+    s, c = math.sin(t), math.cos(t)
+    return np.array([[s, 0, c], [-c, 0, s], [0, -1, 0]], dtype=np.float64)
+
+
+CAMERAS = [
+    ('front', '/semantic/front',  np.array([ 0.70, -0.15, 1.88]), R_cb(  0.0)),
+    ('right', '/semantic/right',  np.array([ 0.70, -0.15, 1.88]), R_cb(-70.0)),
+    ('left',  '/semantic/left',   np.array([ 0.70,  0.15, 1.88]), R_cb( 70.0)),
+    ('back',  '/semantic/back',   np.array([-1.50,  0.00, 1.88]), R_cb(180.0)),
+]
+
+
+class CamLUT:
+    """Precomputed per-pixel -> BEV grid cell mapping for one camera."""
+
+    __slots__ = ('gc', 'gr', 'valid', 'img_h', 'img_w')
+
+    def __init__(self, t_base, R_cb_mat, img_h=IMG_H, img_w=IMG_W):
+        us, vs = np.arange(img_w, dtype=np.float64), np.arange(img_h, dtype=np.float64)
+        uu, vv = np.meshgrid(us, vs)
+        uvh = np.stack([uu.ravel(), vv.ravel(), np.ones(img_h * img_w)])
+        rays_cam = (K_INV @ uvh).T
+        ray_base = (R_cb_mat @ rays_cam.T).T.astype(np.float32)
+
+        rz = ray_base[:, 2]
+        safe = np.abs(rz) > 1e-6
+        with np.errstate(divide='ignore', invalid='ignore'):
+            lam = np.where(safe, -float(t_base[2]) / rz, 0.0)
+
+        px = float(t_base[0]) + lam * ray_base[:, 0]
+        py = float(t_base[1]) + lam * ray_base[:, 1]
+
+        self.gc = ((px - ORIGIN_X) / RESOLUTION).astype(np.int32)
+        self.gr = ((py - ORIGIN_Y) / RESOLUTION).astype(np.int32)
+        d2d = np.hypot(px, py)
+        self.valid = (safe & (lam > 0.0) & (d2d < MAX_PROJ_DIST)
+                      & (self.gc >= 0) & (self.gc < GRID_SIZE)
+                      & (self.gr >= 0) & (self.gr < GRID_SIZE))
+        self.img_h, self.img_w = img_h, img_w

--- a/src/perception/segmentation/segmentation/hybrid_drivable_grid_node.py
+++ b/src/perception/segmentation/segmentation/hybrid_drivable_grid_node.py
@@ -5,6 +5,9 @@ hybrid_drivable_grid_node.py
 Fuses the perception-based drivable grid, the HD-map, and the hybrid occupancy
 grid to produce a real-time /grid/drivable OccupancyGrid.
 
+Modified by Siddarth Nandyala <siddarth.nandyala@utdallas.edu>: publish rate
+bumped 10Hz -> 20Hz to match the rest of the perception grid stack.
+
 Perception is the PRIMARY source.  HD map is a FALLBACK for cells where
 perception is uncertain.  Occupancy grid provides real-time obstacle veto.
 
@@ -76,7 +79,7 @@ class HybridDrivableGridNode(Node):
 
         self.pub = self.create_publisher(OccupancyGrid, '/grid/drivable', 10)
 
-        self.create_timer(0.1, self._publish_loop)
+        self.create_timer(0.05, self._publish_loop)
 
         self._last_hdmap_stamp = None
 

--- a/src/perception/segmentation/segmentation/hybrid_perception_grid_node.py
+++ b/src/perception/segmentation/segmentation/hybrid_perception_grid_node.py
@@ -5,6 +5,9 @@ hybrid_perception_grid_node.py
 Fuses 4-camera semantic segmentation + segmented LiDAR into a 300x300 BEV
 occupancy grid at /grid/occupancy/current.
 
+Modified by Siddarth Nandyala <siddarth.nandyala@utdallas.edu>: publish rate
+bumped 10Hz -> 20Hz to match the rest of the perception grid stack.
+
 Camera path  : /semantic/{front,right,back,left} (PSPNet RGB output)
                -> ground-plane ray-cast LUT -> grid cells
 LiDAR path   : /lidar/filtered (PointCloud2 in base_link)
@@ -143,7 +146,7 @@ class HybridPerceptionGridNode(Node):
         # 1-Hz LUT rebuild timer -- retries until all cameras have good LUTs
         self.create_timer(1.0, self._lut_timer)
         # 10-Hz publish timer
-        self.create_timer(0.1, self._publish_loop)
+        self.create_timer(0.05, self._publish_loop)
 
         self.get_logger().info('HybridPerceptionGridNode ready (4-camera + segmented LiDAR).')
 

--- a/src/perception/segmentation/segmentation/image_segmentation_node.py
+++ b/src/perception/segmentation/segmentation/image_segmentation_node.py
@@ -2,6 +2,11 @@
 image_segmentation_node.py
 Runs PSPNet (mmseg v1.x) on 4 CARLA cameras in a round-robin background thread.
 Callbacks only store the latest frame — no blocking inference in the spin thread.
+
+Modified by Siddarth Nandyala <siddarth.nandyala@utdallas.edu>: moved inference
+onto cuda:1 (kept off GPU0 to avoid contending with CARLA's own rendering),
+and added the stamp-gated re-processing guard so a cached frame isn't
+reprocessed/re-published faster than new camera frames actually arrive.
 """
 
 import threading
@@ -60,8 +65,8 @@ class ImageSegmentationNode(Node):
 
     def __init__(self):
         super().__init__('image_segmentation_node')
-        self.get_logger().info('Loading PSPNet on CPU…')
-        self.model  = init_model(_CONFIG, _CKPT, device='cpu')
+        self.get_logger().info("Loading PSPNet on GPU (cuda:1, kept off GPU0 to avoid contending with CARLA rendering)…")
+        self.model  = init_model(_CONFIG, _CKPT, device="cuda:1")
         self.bridge = CvBridge()
         self.get_logger().info('PSPNet ready.')
 
@@ -98,12 +103,21 @@ class ImageSegmentationNode(Node):
         import time
         n = len(self._order)
         self.get_logger().info('Inference thread running (round-robin 4 cameras).')
+        # Track the last frame stamp we actually ran inference on per camera.
+        # On GPU, inference is fast enough that without this check the loop
+        # re-processes and re-publishes the same cached frame hundreds of
+        # times a second while waiting for the camera's next real frame,
+        # flooding downstream perception nodes and the DDS graph. Only run
+        # inference when a genuinely new frame has arrived.
+        last_stamp = {cam: None for cam in self._order}
         while True:
             cam = self._order[self._idx]
             with self._lock:
                 msg, pub = self._latest[cam]
 
-            if msg is not None:
+            stamp = msg.header.stamp if msg is not None else None
+            if msg is not None and stamp != last_stamp[cam]:
+                last_stamp[cam] = stamp
                 try:
                     img       = self.bridge.imgmsg_to_cv2(msg, 'rgb8')[:, :, :3]
                     result    = inference_model(self.model, img)
@@ -115,7 +129,7 @@ class ImageSegmentationNode(Node):
                 except Exception as e:
                     self.get_logger().error(f'Inference error on {cam}: {e}')
             else:
-                time.sleep(0.05)
+                time.sleep(0.01)
 
             self._idx = (self._idx + 1) % n
 

--- a/src/perception/segmentation/segmentation/perception_drivable_grid_node.py
+++ b/src/perception/segmentation/segmentation/perception_drivable_grid_node.py
@@ -2,7 +2,11 @@
 """
 perception_drivable_grid_node.py  —  Camera-first real-time drivable area grid
 
-Pipeline  (10 Hz)
+Modified by Siddarth Nandyala <siddarth.nandyala@utdallas.edu>: publish rate
+bumped 10Hz -> 20Hz (ALPHA_BLEND/DECAY_RATE rescaled by sqrt() to preserve
+the same real-time EMA smoothing constant at the new rate).
+
+Pipeline  (20 Hz)
   1. Project PSPNet semantic images -> per-cell road observations (LUT at init)
   2. Cross-validate with LiDAR ground/obstacle evidence
   3. Temporal accumulation with odometry pose compensation
@@ -59,8 +63,11 @@ CC_UNCERTAIN_LO    = 0.35   # flood fill only boosts cells in this uncertain ban
 CC_UNCERTAIN_HI    = 0.65
 CC_FILL_VALUE      = 0.70   # evidence assigned to flood-fill-reached uncertain cells
 
-ALPHA_BLEND   = 0.65
-DECAY_RATE    = 0.992
+ALPHA_BLEND   = 0.8062   # sqrt(0.65): publish loop moved 10Hz->20Hz;
+                             # rescaled so the EMA keeps the same real-time
+                             # smoothing constant instead of reacting 2x faster
+                             # to per-frame camera noise
+DECAY_RATE    = 0.9960   # sqrt(0.992), same reasoning
 INIT_EVIDENCE = 0.50
 
 PATH_HISTORY_MAXLEN = 50   # ~12 s at 4 Hz odom = 800 bytes
@@ -180,7 +187,7 @@ class PerceptionDrivableGridNode(Node):
         self.create_subscription(Odometry, '/gnss/odometry',    self._cb_odom,  qos_be)
 
         self.pub = self.create_publisher(OccupancyGrid, '/grid/drivable/segmented', 10)
-        self.create_timer(0.1, self._publish_loop)
+        self.create_timer(0.05, self._publish_loop)
         self.get_logger().info('PerceptionDrivableGridNode ready — /grid/drivable/segmented')
 
     # ── callbacks ─────────────────────────────────────────────────────────────

--- a/src/perception/segmentation/segmentation/yolopv2_lane_node.py
+++ b/src/perception/segmentation/segmentation/yolopv2_lane_node.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+yolopv2_lane_node.py — real-time lane-line segmentation via a pretrained
+YOLOPv2 model, replacing the front camera's hand-built top-hat marking
+detector.
+
+Author: Siddarth Nandyala
+Email: siddarth.nandyala@utdallas.edu
+
+Model: YOLOPv2 (https://github.com/CAIC-AD/YOLOPv2), official pretrained
+release weights (yolopv2.pt), trained on BDD100K real-world driving data.
+Weights file location on this project's hosts: /navigator_binaries/yolopv2.pt
+(same convention as lane_type_detector's lane_detector.pt -- a host-mounted
+binaries directory, not tracked in this git repo). Loaded once at node
+startup via torch.jit.load (self-contained TorchScript, no separate model
+definition code required).
+
+How it works: one shared convolutional backbone feeds three task heads --
+object detection, drivable-area segmentation, and lane-line segmentation.
+This node only uses the drivable-area and lane-line heads. Per frame: the
+raw camera image is letterboxed (resized + padded) to the model's input
+size, run through the model in a single forward pass, and the two
+resulting per-pixel score maps are thresholded into binary masks and
+mapped back to the raw image's native resolution (undoing the letterbox --
+see yolopv2_preprocessing.py) before publishing.
+
+Today's from-scratch approach (morphological top-hat filter + geometric
+barrier-fitting + temporal confirmation, all in camera_lane_evidence.py/
+lane_barrier_fitting.py/lane_line_tracker.py) went through several
+redesigns live and never reached a stable result. Offline validation
+against a real captured CARLA front-camera frame found YOLOPv2 (a
+real-time multi-task model pretrained on BDD100K -- drivable area +
+lane-line segmentation + object detection) produces a dramatically better,
+cleaner lane-line mask than anything built by hand today, and than the
+project's other existing lane_detector.pt model (which found zero
+detections on the same frame). Steady-state inference is ~7ms/frame
+(139 FPS) on cuda:1 once warmed up -- not a performance concern.
+
+Model is loaded via torch.jit.load from a self-contained TorchScript file
+(/navigator_binaries/yolopv2.pt, the official release weights) -- no need
+to vendor YOLOPv2's own training/repo code, only the tiny mask-extraction
+pixel math its own utils.py does (see yolopv2_preprocessing.py, which
+reimplements it using this project's own actual letterbox padding rather
+than YOLOPv2's hardcoded crop constants -- those assume a different input
+aspect ratio than this project's 4:3 camera frames).
+
+Front camera only for this phase: YOLOPv2 is pretrained on forward-facing
+dashcam data; our side cameras are mounted at a ~70 degree yaw (a real
+domain shift from what it was trained on), and validating it there needs
+its own live test before trusting it. camera_lane_evidence.py's top-hat
+approach stays in place for the right/left cameras in lane_grid_node.py.
+
+Structure mirrors image_segmentation_node.py (the only other model-loading
+node in this package) exactly: model loaded once in __init__ on cuda:1
+(same GPU as PSPNet, kept off GPU0 to avoid contending with CARLA's own
+rendering), subscription callback only stores the latest frame, a single
+daemon background thread does stamp-gated inference so a cached frame is
+never reprocessed/re-published in a tight loop.
+
+Publishes two topics: /lane_mask/front (mono8 binary mask, what
+lane_grid_node actually consumes) and /lane_mask/front/viz (bgr8, a
+human-viewable overlay -- green drivable area + red lane lines drawn over
+the raw camera frame -- for direct visual verification in RViz, matching
+the same green/red visualization style used in this model's own offline
+demo tooling).
+"""
+
+import threading
+import time
+
+import cv2
+import numpy as np
+import rclpy
+import torch
+from cv_bridge import CvBridge
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, QoSReliabilityPolicy, QoSHistoryPolicy, QoSDurabilityPolicy
+from sensor_msgs.msg import Image
+
+from segmentation.yolopv2_preprocessing import letterbox, unletterbox_mask
+
+_WEIGHTS = '/navigator_binaries/yolopv2.pt'
+_RAW_TOPIC = '/cameras/camera0'
+_MASK_TOPIC = '/lane_mask/front'
+_VIZ_TOPIC = '/lane_mask_viz/front'
+_LANE_LINE_THRESHOLD = 0.5  # model's ll head output is already probability-like (0-1); round() at 0.5
+
+_DRIVABLE_COLOR_BGR = (0, 200, 0)    # green
+_LANE_LINE_COLOR_BGR = (0, 0, 230)   # red
+_DRIVABLE_ALPHA = 0.5                # blend weight for the drivable-area fill
+
+
+def _make_overlay(raw_bgr, drivable_mask, lane_mask):
+    """raw_bgr: HxWx3 uint8. drivable_mask/lane_mask: HxW bool, already at
+    raw_bgr's own resolution. Returns an HxWx3 uint8 overlay: a
+    semi-transparent green fill over the drivable area, with lane-line
+    pixels drawn solid red on top -- same visual language as YOLOPv2's own
+    offline demo visualization, so a live RViz view reads the same way the
+    offline validation frame did.
+    """
+    overlay = raw_bgr.copy()
+    if drivable_mask.any():
+        tint = np.full_like(raw_bgr, _DRIVABLE_COLOR_BGR)
+        blended = cv2.addWeighted(raw_bgr, 1 - _DRIVABLE_ALPHA, tint, _DRIVABLE_ALPHA, 0)
+        overlay[drivable_mask] = blended[drivable_mask]
+    overlay[lane_mask] = _LANE_LINE_COLOR_BGR
+    return overlay
+
+
+class Yolopv2LaneNode(Node):
+
+    def __init__(self):
+        super().__init__('yolopv2_lane_node')
+        self.get_logger().info("Loading YOLOPv2 on GPU (cuda:1, same as PSPNet, kept off GPU0)…")
+        self.device = torch.device('cuda:1')
+        self.model = torch.jit.load(_WEIGHTS)
+        self.model = self.model.to(self.device).half()
+        self.model.eval()
+        self.bridge = CvBridge()
+        self.get_logger().info('YOLOPv2 ready.')
+
+        image_qos = QoSProfile(
+            history=QoSHistoryPolicy.KEEP_LAST,
+            reliability=QoSReliabilityPolicy.BEST_EFFORT,
+            depth=1,
+            durability=QoSDurabilityPolicy.VOLATILE,
+        )
+
+        self._latest = None
+        self._lock = threading.Lock()
+        self.create_subscription(Image, _RAW_TOPIC, self._store, image_qos)
+
+        self.lane_pub = self.create_publisher(Image, _MASK_TOPIC, 1)
+        self.viz_pub = self.create_publisher(Image, _VIZ_TOPIC, 1)
+
+        threading.Thread(target=self._loop, daemon=True).start()
+        self.get_logger().info(f'  {_RAW_TOPIC} → {_MASK_TOPIC}, {_VIZ_TOPIC}')
+
+    # ── callback: just store, never block ───────────────────────────────
+    def _store(self, msg: Image):
+        with self._lock:
+            self._latest = msg
+
+    # ── inference loop ───────────────────────────────────────────────────
+    def _loop(self):
+        # Same reasoning as image_segmentation_node.py's inference loop:
+        # on GPU, inference is fast enough that without this check we'd
+        # re-process and re-publish the same cached frame far faster than
+        # new camera frames actually arrive.
+        last_stamp = None
+        self.get_logger().info('Inference thread running.')
+        while True:
+            with self._lock:
+                msg = self._latest
+
+            stamp = msg.header.stamp if msg is not None else None
+            if msg is not None and stamp != last_stamp:
+                last_stamp = stamp
+                try:
+                    self._infer_and_publish(msg)
+                except Exception as e:
+                    self.get_logger().error(f'Inference error: {e}')
+            else:
+                time.sleep(0.01)
+
+    def _infer_and_publish(self, msg: Image):
+        raw = self.bridge.imgmsg_to_cv2(msg, 'bgr8')
+        original_shape = raw.shape[:2]
+
+        padded, ratio, pad = letterbox(raw)
+        img_in = padded[:, :, ::-1].transpose(2, 0, 1).copy()  # BGR -> RGB, HWC -> CHW
+        img_t = torch.from_numpy(img_in).to(self.device).half() / 255.0
+        img_t = img_t.unsqueeze(0)
+
+        with torch.no_grad():
+            [_pred, _anchor_grid], seg, ll = self.model(img_t)
+
+        lane_line = (ll.squeeze(0).squeeze(0) >= _LANE_LINE_THRESHOLD).cpu().numpy()
+        lane_mask = unletterbox_mask(lane_line, pad, original_shape)
+
+        out_msg = self.bridge.cv2_to_imgmsg((lane_mask * 255).astype(np.uint8), encoding='mono8')
+        out_msg.header = msg.header
+        self.lane_pub.publish(out_msg)
+
+        # Visualization branch: cheap on top of the forward pass we already
+        # ran (just one more argmax over the seg head's 2 channels).
+        drivable = torch.max(seg, 1)[1].squeeze(0).cpu().numpy().astype(bool)
+        drivable_mask = unletterbox_mask(drivable, pad, original_shape).astype(bool)
+        overlay = _make_overlay(raw, drivable_mask, lane_mask.astype(bool))
+        viz_msg = self.bridge.cv2_to_imgmsg(overlay, encoding='bgr8')
+        viz_msg.header = msg.header
+        self.viz_pub.publish(viz_msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    rclpy.spin(Yolopv2LaneNode())
+
+
+if __name__ == '__main__':
+    main()

--- a/src/perception/segmentation/segmentation/yolopv2_preprocessing.py
+++ b/src/perception/segmentation/segmentation/yolopv2_preprocessing.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+yolopv2_preprocessing.py — letterbox resize and its inverse, for feeding a
+camera frame into YOLOPv2 and mapping its output mask back to native pixel
+coordinates.
+
+Author: Siddarth Nandyala
+Email: siddarth.nandyala@utdallas.edu
+
+Model: YOLOPv2 (https://github.com/CAIC-AD/YOLOPv2), official pretrained
+release weights (yolopv2.pt) at /navigator_binaries/yolopv2.pt -- see
+yolopv2_lane_node.py (the node that actually loads and runs the model) for
+the full explanation of how the model works. This module only holds the
+pure pixel-math pre/post-processing YOLOPv2's own preprocessing convention
+requires: resize+pad the input to the model's expected size (letterbox),
+and invert that resize+pad on the model's output mask so it lines back up
+with the original, un-letterboxed camera frame.
+
+Split out from yolopv2_lane_node.py so this pure cv2/numpy pixel math is
+unit-testable without pulling in torch/rclpy/cv_bridge -- same separation
+of concerns as camera_lane_evidence.py (pure) vs. lane_grid_node.py (ROS
+node), elsewhere in this package.
+
+Pure numpy/opencv, no rclpy/torch -- unit-testable standalone.
+"""
+
+import cv2
+import numpy as np
+
+DEFAULT_MODEL_INPUT_SIZE = 640
+DEFAULT_STRIDE = 32
+
+
+def letterbox(img, new_shape=DEFAULT_MODEL_INPUT_SIZE, color=(114, 114, 114), stride=DEFAULT_STRIDE):
+    """Resize+pad img to fit within new_shape (a single int -> square
+    target) while preserving aspect ratio, padding the shorter dimension
+    to a stride-multiple -- same algorithm YOLOPv2's own preprocessing
+    uses (simplified here to the one mode we need: auto/minimum-rectangle,
+    scaleup allowed).
+
+    Returns (padded_img, ratio, (pad_w, pad_h)). For this project's 800x600
+    CARLA camera frames specifically, this produces an exact 640x480 fit
+    with zero padding (4:3 matches 4:3) -- confirmed empirically -- but the
+    general padding math is kept so this doesn't silently break if the
+    camera resolution ever changes.
+    """
+    if isinstance(new_shape, int):
+        new_shape = (new_shape, new_shape)
+    shape = img.shape[:2]  # h, w
+
+    r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
+    new_unpad = (int(round(shape[1] * r)), int(round(shape[0] * r)))  # w, h
+    dw, dh = new_shape[1] - new_unpad[0], new_shape[0] - new_unpad[1]
+    dw, dh = dw % stride, dh % stride
+    dw /= 2
+    dh /= 2
+
+    if shape[::-1] != new_unpad:
+        img = cv2.resize(img, new_unpad, interpolation=cv2.INTER_LINEAR)
+
+    top, bottom = int(round(dh - 0.1)), int(round(dh + 0.1))
+    left, right = int(round(dw - 0.1)), int(round(dw + 0.1))
+    img = cv2.copyMakeBorder(img, top, bottom, left, right, cv2.BORDER_CONSTANT, value=color)
+    return img, r, (dw, dh)
+
+
+def unletterbox_mask(mask, pad, original_shape):
+    """Inverse of letterbox() for a mask that came out of the model at the
+    same resolution as the letterboxed input (confirmed empirically for
+    YOLOPv2: its seg/lane-line heads output at input resolution, no
+    internal up/downsampling -- unlike YOLOPv2's own demo code, which
+    assumes a fixed input aspect ratio and hardcodes its own crop
+    constants accordingly; that assumption doesn't hold for this
+    project's 4:3 camera frames, so this crops using the actual pad
+    values from our own letterbox() call instead).
+
+    Crops off the padding, then resizes the remaining (real-content)
+    region up to original_shape -- so the result is pixel-aligned with the
+    raw, pre-letterbox camera frame. mask: 2D array. pad: (pad_w, pad_h)
+    exactly as returned by letterbox() for the same frame. original_shape:
+    (h, w) of the raw camera image.
+    """
+    dw, dh = pad
+    h, w = mask.shape
+    top, bottom = int(round(dh - 0.1)), h - int(round(dh + 0.1))
+    left, right = int(round(dw - 0.1)), w - int(round(dw + 0.1))
+    cropped = mask[top:bottom, left:right]
+    out_h, out_w = original_shape
+    return cv2.resize(cropped.astype(np.uint8), (out_w, out_h), interpolation=cv2.INTER_NEAREST)

--- a/src/perception/segmentation/setup.py
+++ b/src/perception/segmentation/setup.py
@@ -28,6 +28,7 @@ setup(
             'hybrid_perception_grid_node = segmentation.hybrid_perception_grid_node:main',
             'perception_drivable_grid_node = segmentation.perception_drivable_grid_node:main',
             'hybrid_drivable_grid_node = segmentation.hybrid_drivable_grid_node:main',
+            'yolopv2_lane_node = segmentation.yolopv2_lane_node:main',
         ],
     },
 )

--- a/src/perception/segmentation/test/test_yolopv2_preprocessing.py
+++ b/src/perception/segmentation/test/test_yolopv2_preprocessing.py
@@ -1,0 +1,81 @@
+"""Unit tests for yolopv2_preprocessing.py — no ROS, no torch, no model
+required.
+
+Run with: python3 -m pytest src/perception/segmentation/test/test_yolopv2_preprocessing.py
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from segmentation import yolopv2_preprocessing as yln
+
+
+def test_letterbox_exact_aspect_match_has_zero_padding():
+    """Confirmed empirically live: an 800x600 (4:3) CARLA frame letterboxed
+    to a 640-based target lands on an exact 640x480 fit with no padding
+    needed at all -- this is the common case for this project's cameras,
+    and worth pinning down as a regression test."""
+    img = np.zeros((600, 800, 3), dtype=np.uint8)
+
+    padded, ratio, pad = yln.letterbox(img, new_shape=640)
+
+    assert padded.shape[:2] == (480, 640)
+    assert ratio == pytest.approx(0.8)
+    assert pad == (0.0, 0.0)
+
+
+def test_letterbox_pads_a_mismatched_aspect_ratio():
+    """A square source scaled against a square target always fits exactly
+    (both dimensions scale identically) -- this needs a source whose
+    scaled dimension actually lands off a stride-32 multiple to exercise
+    padding at all. 600x500 scaled to fit a 640 target is height-
+    constrained (scale factor 640/600), leaving the scaled width (533) 11
+    short of the next stride-32 multiple (544)."""
+    img = np.zeros((600, 500, 3), dtype=np.uint8)  # h=600, w=500
+
+    padded, ratio, pad = yln.letterbox(img, new_shape=640, stride=32)
+
+    dw, dh = pad
+    assert dh == 0  # height already lands exactly on the target
+    assert dw > 0  # width needs padding to reach the next stride-32 multiple
+    assert padded.shape[:2] == (640, 544)  # height untouched, width padded up to a multiple of 32
+
+
+def test_unletterbox_mask_recovers_original_shape_with_zero_padding():
+    original_shape = (600, 800)
+    mask = np.zeros((480, 640), dtype=bool)
+    mask[100:110, 200:210] = True  # a small marked region
+
+    recovered = yln.unletterbox_mask(mask, pad=(0.0, 0.0), original_shape=original_shape)
+
+    assert recovered.shape == original_shape
+    # The marked region should still be present, scaled up proportionally
+    # (480->600 is 1.25x, 640->800 is 1.25x).
+    assert recovered[int(100 * 1.25):int(110 * 1.25), int(200 * 1.25):int(210 * 1.25)].any()
+    assert not recovered[0:50, 0:50].any()
+
+
+def test_unletterbox_mask_crops_padding_before_resizing():
+    """A mask with real content only in the unpadded center region should
+    have that content correctly recovered at the original image's full
+    extent once the padding is cropped off -- not squashed/offset by
+    treating the padding as real content."""
+    original_shape = (200, 200)
+    mask = np.zeros((100, 120), dtype=bool)
+    # Real content occupies the middle columns; columns 0:10 and 110:120
+    # simulate left/right letterbox padding (never marked).
+    mask[:, 10:110] = True
+
+    recovered = yln.unletterbox_mask(mask, pad=(10.0, 0.0), original_shape=original_shape)
+
+    assert recovered.shape == original_shape
+    assert recovered.all()  # padding cropped away, remaining content fills the full recovered mask
+
+
+if __name__ == '__main__':
+    sys.exit(pytest.main([__file__, '-v']))


### PR DESCRIPTION
## Summary

- Adds real-time drivable-area + lane-line segmentation on the front camera using a pretrained **YOLOPv2** model (`yolopv2_lane_node.py`, `yolopv2_preprocessing.py`), replacing a hand-built detector that never reached a stable result in live testing.
- YOLOPv2 is a real-time multi-task network (drivable-area + lane-line segmentation + object detection, one shared backbone) trained on real-world driving data (BDD100K). It produced dramatically cleaner masks than the hand-built approach on the same test frames.
  - Weights: official release `yolopv2.pt`, at `/navigator_binaries/yolopv2.pt` — same host-mounted binaries directory this project already uses for other model weights (e.g. `lane_detector.pt`), not tracked in this repo.
  - Publishes `/lane_mask/front` (binary lane-line mask, native camera resolution) and `/lane_mask_viz/front` (a human-viewable green drivable-area + red lane-line overlay, for direct RViz viewing).
  - Front camera only for this phase: YOLOPv2 is pretrained on forward-facing dashcam footage; this project's side cameras sit at a ~70° yaw, a real domain shift that needs its own separate validation before extending it there.

## Also included

- `perception_drivable_grid_node.py`, `hybrid_drivable_grid_node.py`, `hybrid_perception_grid_node.py`: publish rate bumped 10Hz → 20Hz to match the rest of the perception stack (EMA constants rescaled by `sqrt()` to preserve the same real-time smoothing behavior at the new rate).
- `image_segmentation_node.py`: PSPNet inference moved to `cuda:1` (kept off GPU0 to avoid contending with CARLA's own rendering), plus a stamp-gated guard so a cached frame isn't reprocessed/republished faster than new camera frames arrive.
- `lane_type_detector.py`: fixed a `cv_bridge` image-encoding crash (was requesting the invalid `'8UC3'` conversion target instead of `'bgr8'`) and a hardcoded frame-width assumption that didn't match the camera's actual resolution.
- `launch.perception.py` / `launch_node_definitions.py`: wire in `image_segmentation` and `yolopv2_lane`, neither of which were previously included in the launch graph.
- `bev_geometry.py` (shared camera-to-BEV ground-plane projection) is included as groundwork but not yet consumed by anything in this PR.
